### PR TITLE
fix : 이중 조인 해결 Item으로 수정

### DIFF
--- a/src/main/java/com/example/tradedemo/domain/order/entity/Order.java
+++ b/src/main/java/com/example/tradedemo/domain/order/entity/Order.java
@@ -1,6 +1,7 @@
 package com.example.tradedemo.domain.order.entity;
 
 import com.example.tradedemo.common.entity.Base;
+import com.example.tradedemo.domain.item.entity.Item;
 import com.example.tradedemo.domain.marketlistings.entity.MarketListing;
 import com.example.tradedemo.domain.members.entity.Member;
 import jakarta.persistence.*;
@@ -57,10 +58,11 @@ public class Order extends Base {
 
     /**
      * 거래 매물 ID : item_id
+     * 아이템의 아이디나 이름을 사용할 수 있다.
      */
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "item_id", nullable = false)
-    private MarketListing itemId;
+    private Item item;
 
     /**
      * 정적 팩토리 메서드
@@ -71,14 +73,14 @@ public class Order extends Base {
             Member seller,
             Member buyer,
             MarketListing marketListing,
-            MarketListing itemId) {
+            Item item) {
         Order order = new Order();
         order.transactionMoney = transactionMoney;
         order.transactionStock = transactionStock;
         order.seller = seller;
         order.buyer = buyer;
         order.marketListing = marketListing;
-        order.itemId = itemId;
+        order.item = item;
 
         return order;
     }


### PR DESCRIPTION
# Work History
- 거래 매물의 id와 거래 매물의 판매자의 인벤토리에서 아이템 도감의 id를 가져오는 것 이중 구조에서 수정
- 거래 매물의 id와 거래 매물의 id에 대한 아이템의 id로 수정하였습니다.

# Releated Issue
관련 이슈에 따라 아래 키워드를 사용할 것


# CheckList
- [ ] Commit Convention 준수 여부 확인
- [ ] 코드에 대해서 주석 작성 여부 확인
- [ ] 불필요 주석, import, Test Log 삭제 여부 확인

# ETC
코드에 대한 설명이나 후처리에 관해 기록할 사항을 적을 것