### PR TITLE
feat: 쿠폰 정책 생성

### DIFF
--- a/src/main/java/com/example/tradedemo/TradeDemoApplication.java
+++ b/src/main/java/com/example/tradedemo/TradeDemoApplication.java
@@ -2,8 +2,10 @@ package com.example.tradedemo;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class TradeDemoApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/example/tradedemo/common/consts/ErrorMessage.java
+++ b/src/main/java/com/example/tradedemo/common/consts/ErrorMessage.java
@@ -14,4 +14,6 @@ public final class ErrorMessage {
     // Wallet
 
     // Coupon
+    public static final String MSG_COUPON_POLICY_DUPLICATE_NAME = "이미 존재하는 쿠폰 정책 이름입니다";
+    public static final String MSG_COUPON_POLICY_FIRST_COME_QUANTITY_REQUIRED = "선착순 쿠폰은 총 수량이 필수입니다";
 }

--- a/src/main/java/com/example/tradedemo/common/converter/DurationConverter.java
+++ b/src/main/java/com/example/tradedemo/common/converter/DurationConverter.java
@@ -1,0 +1,20 @@
+package com.example.tradedemo.common.converter;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+import java.time.Duration;
+
+@Converter(autoApply = false)
+public class DurationConverter implements AttributeConverter<Duration, Long> {
+    // Duration → DB (초 단위로 저장)
+    @Override
+    public Long convertToDatabaseColumn(Duration duration) {
+        return duration == null ? null : duration.toSeconds();
+    }
+
+    // DB → Duration
+    @Override
+    public Duration convertToEntityAttribute(Long seconds) {
+        return seconds == null ? null : Duration.ofSeconds(seconds);
+    }
+}

--- a/src/main/java/com/example/tradedemo/common/exception/ErrorEnum.java
+++ b/src/main/java/com/example/tradedemo/common/exception/ErrorEnum.java
@@ -10,7 +10,12 @@ import org.springframework.http.HttpStatus;
 public enum ErrorEnum {
 
     // Member
-    ERR_MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, ErrorMessage.MSG_MEMBER_NOT_FOUND);
+    ERR_MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, ErrorMessage.MSG_MEMBER_NOT_FOUND),
+
+    // Coupon
+    ERR_COUPON_POLICY_DUPLICATE_NAME(HttpStatus.CONFLICT, ErrorMessage.MSG_COUPON_POLICY_DUPLICATE_NAME),
+    ERR_COUPON_POLICY_FIRST_COME_QUANTITY_REQUIRED(
+            HttpStatus.BAD_REQUEST, ErrorMessage.MSG_COUPON_POLICY_FIRST_COME_QUANTITY_REQUIRED);
 
     private final HttpStatus httpStatus;
     private final String errorMessage;

--- a/src/main/java/com/example/tradedemo/domain/coupon/constants/CouponDuration.java
+++ b/src/main/java/com/example/tradedemo/domain/coupon/constants/CouponDuration.java
@@ -1,0 +1,30 @@
+package com.example.tradedemo.domain.coupon.constants;
+
+import com.example.tradedemo.domain.coupon.enums.IssueType;
+import java.time.Duration;
+
+public final class CouponDuration {
+
+    // 정책 유효기간
+    public static final Duration FIRST_COME_POLICY = Duration.ofDays(3); // 선착순 이벤트 3일
+
+    // 쿠폰 유효기간
+    public static final Duration FIRST_COME_COUPON = Duration.ofDays(7); // 선착순 쿠폰 7일
+    public static final Duration AUTO_SIGNUP_COUPON = null; // 회원가입 쿠폰 무제한
+
+    private CouponDuration() {}
+
+    public static Duration getPolicyDuration(IssueType issueType) {
+        return switch (issueType) {
+            case FIRST_COME -> FIRST_COME_POLICY;
+            case AUTO_SIGNUP -> null; // 정책 만료 없음
+        };
+    }
+
+    public static Duration getCouponDuration(IssueType issueType) {
+        return switch (issueType) {
+            case FIRST_COME -> FIRST_COME_COUPON;
+            case AUTO_SIGNUP -> AUTO_SIGNUP_COUPON; // null (무제한)
+        };
+    }
+}

--- a/src/main/java/com/example/tradedemo/domain/coupon/controller/CouponController.java
+++ b/src/main/java/com/example/tradedemo/domain/coupon/controller/CouponController.java
@@ -1,11 +1,27 @@
 package com.example.tradedemo.domain.coupon.controller;
 
+import com.example.tradedemo.common.dto.ApiResponse;
+import com.example.tradedemo.domain.coupon.dto.CreateCouponPolicyRequest;
+import com.example.tradedemo.domain.coupon.dto.CreateCouponPolicyResponse;
 import com.example.tradedemo.domain.coupon.service.CouponService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
 public class CouponController {
     private final CouponService couponService;
+
+    @PostMapping("/api/v1/admin/coupon-policies")
+    public ResponseEntity<ApiResponse<CreateCouponPolicyResponse>> createCouponPolicy(
+            @Valid @RequestBody CreateCouponPolicyRequest request) {
+        CreateCouponPolicyResponse response = couponService.createCouponPolicy(request);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.success(String.valueOf(HttpStatus.OK.value()), response));
+    }
 }

--- a/src/main/java/com/example/tradedemo/domain/coupon/dto/CreateCouponPolicyRequest.java
+++ b/src/main/java/com/example/tradedemo/domain/coupon/dto/CreateCouponPolicyRequest.java
@@ -1,0 +1,43 @@
+package com.example.tradedemo.domain.coupon.dto;
+
+import com.example.tradedemo.domain.coupon.enums.IssueType;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import java.math.BigDecimal;
+import lombok.Getter;
+
+@Getter
+public class CreateCouponPolicyRequest {
+    @NotBlank(message = "쿠폰 정책 이름은 필수입니다")
+    private final String name;
+
+    @NotNull(message = "지급 금액은 필수입니다")
+    @Positive(message = "지급 금액은 0보다 커야 합니다")
+    private final BigDecimal moneyAmount;
+
+    @NotNull(message = "발급 타입은 필수입니다")
+    private final IssueType issueType;
+
+    // FIRST_COME 이면 필수, AUTO_SIGNUP 이면 null
+    private final Long totalQuantity;
+
+    @JsonCreator
+    private CreateCouponPolicyRequest(
+            @JsonProperty("name") String name,
+            @JsonProperty("moneyAmount") BigDecimal moneyAmount,
+            @JsonProperty("issueType") IssueType issueType,
+            @JsonProperty("totalQuantity") Long totalQuantity) {
+        this.name = name;
+        this.moneyAmount = moneyAmount;
+        this.issueType = issueType;
+        this.totalQuantity = totalQuantity;
+    }
+
+    public static CreateCouponPolicyRequest of(
+            String name, BigDecimal moneyAmount, IssueType issueType, Long totalQuantity) {
+        return new CreateCouponPolicyRequest(name, moneyAmount, issueType, totalQuantity);
+    }
+}

--- a/src/main/java/com/example/tradedemo/domain/coupon/dto/CreateCouponPolicyResponse.java
+++ b/src/main/java/com/example/tradedemo/domain/coupon/dto/CreateCouponPolicyResponse.java
@@ -1,0 +1,68 @@
+package com.example.tradedemo.domain.coupon.dto;
+
+import com.example.tradedemo.domain.coupon.entity.CouponPolicy;
+import com.example.tradedemo.domain.coupon.enums.IssueType;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import lombok.Getter;
+
+@Getter
+public class CreateCouponPolicyResponse {
+
+    private final Long id;
+    private final String name;
+    private final BigDecimal moneyAmount;
+    private final IssueType issueType;
+    private final Long totalQuantity;
+    private final Long expendQuantity;
+    private final LocalDateTime policyStartedAt;
+    private final LocalDateTime policyExpiredAt;
+    private final Long policyDurationSeconds;
+    private final Long couponDurationSeconds;
+    private final LocalDateTime createdAt;
+    private final LocalDateTime modifiedAt;
+
+    private CreateCouponPolicyResponse(
+            Long id,
+            String name,
+            BigDecimal moneyAmount,
+            IssueType issueType,
+            Long totalQuantity,
+            Long expendQuantity,
+            LocalDateTime policyStartedAt,
+            LocalDateTime policyExpiredAt,
+            Long policyDurationSeconds,
+            Long couponDurationSeconds,
+            LocalDateTime createdAt,
+            LocalDateTime modifiedAt) {
+
+        this.id = id;
+        this.name = name;
+        this.moneyAmount = moneyAmount;
+        this.issueType = issueType;
+        this.totalQuantity = totalQuantity;
+        this.expendQuantity = expendQuantity;
+        this.policyStartedAt = policyStartedAt;
+        this.policyExpiredAt = policyExpiredAt;
+        this.policyDurationSeconds = policyDurationSeconds;
+        this.couponDurationSeconds = couponDurationSeconds;
+        this.createdAt = createdAt;
+        this.modifiedAt = modifiedAt;
+    }
+
+    public static CreateCouponPolicyResponse from(CouponPolicy policy) {
+        return new CreateCouponPolicyResponse(
+                policy.getId(),
+                policy.getName(),
+                policy.getMoneyAmount(),
+                policy.getIssueType(),
+                policy.getTotalQuantity(),
+                policy.getExpendQuantity(),
+                policy.getPolicyStartedAt(),
+                policy.getPolicyExpiredAt(),
+                policy.getPolicyDuration() != null ? policy.getPolicyDuration().toSeconds() : null,
+                policy.getCouponDuration() != null ? policy.getCouponDuration().toSeconds() : null,
+                policy.getCreatedAt(),
+                policy.getModifiedAt());
+    }
+}

--- a/src/main/java/com/example/tradedemo/domain/coupon/entity/CouponHistory.java
+++ b/src/main/java/com/example/tradedemo/domain/coupon/entity/CouponHistory.java
@@ -1,6 +1,7 @@
 package com.example.tradedemo.domain.coupon.entity;
 
 import com.example.tradedemo.common.entity.Base;
+import com.example.tradedemo.domain.coupon.enums.CouponHistoryStatus;
 import com.example.tradedemo.domain.members.entity.Member;
 import jakarta.persistence.*;
 import java.math.BigDecimal;

--- a/src/main/java/com/example/tradedemo/domain/coupon/entity/CouponPolicy.java
+++ b/src/main/java/com/example/tradedemo/domain/coupon/entity/CouponPolicy.java
@@ -1,8 +1,11 @@
 package com.example.tradedemo.domain.coupon.entity;
 
+import com.example.tradedemo.common.converter.DurationConverter;
 import com.example.tradedemo.common.entity.Base;
+import com.example.tradedemo.domain.coupon.enums.IssueType;
 import jakarta.persistence.*;
 import java.math.BigDecimal;
+import java.time.Duration;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -43,11 +46,35 @@ public class CouponPolicy extends Base {
     @Column
     private LocalDateTime policyExpiredAt;
 
-    // 정책 유효기간
+    // 정책 유효기간 Duration → DB에 초 단위로 저장
+    @Convert(converter = DurationConverter.class)
     @Column
-    private Integer policyDuration;
+    private Duration policyDuration;
 
     // 쿠폰 유효기간
+    @Convert(converter = DurationConverter.class)
     @Column
-    private Integer couponDuration;
+    private Duration couponDuration;
+
+    public static CouponPolicy create(
+            String name,
+            BigDecimal moneyAmount,
+            IssueType issueType,
+            Long totalQuantity,
+            LocalDateTime policyStartedAt,
+            LocalDateTime policyExpiredAt,
+            Duration policyDuration,
+            Duration couponDuration) {
+        CouponPolicy policy = new CouponPolicy();
+        policy.name = name;
+        policy.moneyAmount = moneyAmount;
+        policy.issueType = issueType;
+        policy.totalQuantity = totalQuantity;
+        policy.expendQuantity = 0L;
+        policy.policyStartedAt = policyStartedAt;
+        policy.policyExpiredAt = policyExpiredAt;
+        policy.policyDuration = policyDuration;
+        policy.couponDuration = couponDuration;
+        return policy;
+    }
 }

--- a/src/main/java/com/example/tradedemo/domain/coupon/entity/MemberCoupon.java
+++ b/src/main/java/com/example/tradedemo/domain/coupon/entity/MemberCoupon.java
@@ -1,6 +1,7 @@
 package com.example.tradedemo.domain.coupon.entity;
 
 import com.example.tradedemo.common.entity.Base;
+import com.example.tradedemo.domain.coupon.enums.CouponStatus;
 import com.example.tradedemo.domain.members.entity.Member;
 import jakarta.persistence.*;
 import java.time.LocalDateTime;

--- a/src/main/java/com/example/tradedemo/domain/coupon/enums/CouponHistoryStatus.java
+++ b/src/main/java/com/example/tradedemo/domain/coupon/enums/CouponHistoryStatus.java
@@ -1,4 +1,4 @@
-package com.example.tradedemo.domain.coupon.entity;
+package com.example.tradedemo.domain.coupon.enums;
 
 public enum CouponHistoryStatus {
     USED,

--- a/src/main/java/com/example/tradedemo/domain/coupon/enums/CouponStatus.java
+++ b/src/main/java/com/example/tradedemo/domain/coupon/enums/CouponStatus.java
@@ -1,4 +1,4 @@
-package com.example.tradedemo.domain.coupon.entity;
+package com.example.tradedemo.domain.coupon.enums;
 
 public enum CouponStatus {
     UNUSED,

--- a/src/main/java/com/example/tradedemo/domain/coupon/enums/IssueType.java
+++ b/src/main/java/com/example/tradedemo/domain/coupon/enums/IssueType.java
@@ -1,4 +1,4 @@
-package com.example.tradedemo.domain.coupon.entity;
+package com.example.tradedemo.domain.coupon.enums;
 
 public enum IssueType {
     AUTO_SIGNUP, // 회원가입 시 자동지급

--- a/src/main/java/com/example/tradedemo/domain/coupon/repository/CouponPolicyRepository.java
+++ b/src/main/java/com/example/tradedemo/domain/coupon/repository/CouponPolicyRepository.java
@@ -3,4 +3,7 @@ package com.example.tradedemo.domain.coupon.repository;
 import com.example.tradedemo.domain.coupon.entity.CouponPolicy;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface CouponPolicyRepository extends JpaRepository<CouponPolicy, Long> {}
+public interface CouponPolicyRepository extends JpaRepository<CouponPolicy, Long> {
+
+    boolean existsByName(String name);
+}

--- a/src/main/java/com/example/tradedemo/domain/coupon/service/CouponService.java
+++ b/src/main/java/com/example/tradedemo/domain/coupon/service/CouponService.java
@@ -1,15 +1,63 @@
 package com.example.tradedemo.domain.coupon.service;
 
+import com.example.tradedemo.common.exception.ErrorEnum;
+import com.example.tradedemo.common.exception.ServiceException;
+import com.example.tradedemo.domain.coupon.constants.CouponDuration;
+import com.example.tradedemo.domain.coupon.dto.CreateCouponPolicyRequest;
+import com.example.tradedemo.domain.coupon.dto.CreateCouponPolicyResponse;
+import com.example.tradedemo.domain.coupon.entity.CouponPolicy;
+import com.example.tradedemo.domain.coupon.enums.IssueType;
 import com.example.tradedemo.domain.coupon.repository.CouponHistoryRepository;
 import com.example.tradedemo.domain.coupon.repository.CouponPolicyRepository;
 import com.example.tradedemo.domain.coupon.repository.MemberCouponRepository;
+import jakarta.transaction.Transactional;
+import jakarta.validation.Valid;
+import java.time.Duration;
+import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
 public class CouponService {
-    private CouponPolicyRepository couponPolicyRepository;
-    private MemberCouponRepository memberCouponRepository;
-    private CouponHistoryRepository couponHistoryRepository;
+    private final CouponPolicyRepository couponPolicyRepository;
+    private final MemberCouponRepository memberCouponRepository;
+    private final CouponHistoryRepository couponHistoryRepository;
+
+    @Transactional
+    public CreateCouponPolicyResponse createCouponPolicy(@Valid CreateCouponPolicyRequest request) {
+        // 정책 이름 중복 검사
+        if (couponPolicyRepository.existsByName(request.getName())) {
+            throw new ServiceException(ErrorEnum.ERR_COUPON_POLICY_DUPLICATE_NAME);
+        }
+
+        // FIRST_COME 이면 totalQuantity 필수
+        if (request.getIssueType() == IssueType.FIRST_COME && request.getTotalQuantity() == null) {
+            throw new ServiceException(ErrorEnum.ERR_COUPON_POLICY_FIRST_COME_QUANTITY_REQUIRED);
+        }
+
+        // 정책 시작일 = 생성 시점
+        LocalDateTime policyStartedAt = LocalDateTime.now();
+
+        // IssueType 에 따라 상수에서 Duration 자동 선택
+        Duration policyDuration = CouponDuration.getPolicyDuration(request.getIssueType());
+        Duration couponDuration = CouponDuration.getCouponDuration(request.getIssueType());
+
+        // 정책 만료일 = 시작일 + policyDuration (AUTO_SIGNUP 이면 null)
+        LocalDateTime policyExpiredAt = policyDuration != null ? policyStartedAt.plus(policyDuration) : null;
+
+        CouponPolicy couponPolicy = CouponPolicy.create(
+                request.getName(),
+                request.getMoneyAmount(),
+                request.getIssueType(),
+                request.getTotalQuantity(),
+                policyStartedAt,
+                policyExpiredAt,
+                policyDuration,
+                couponDuration);
+
+        CouponPolicy savedPolicy = couponPolicyRepository.save(couponPolicy);
+
+        return CreateCouponPolicyResponse.from(savedPolicy);
+    }
 }


### PR DESCRIPTION
# Work History
- 정책 유효기간, 쿠폰 유효기간 -> 상수로 관리
   - IssueType에 따라 상수를 자동으로 적용하는 방식으로 적용
- Duration을 DB에 저장하려면 JPA가 직접 매핑을 못하기 때문에 Converter를 만들어 사용해야함
   - /common/converter 패키지에 DurationConverter 생성
   - Duration → DB (초 단위로 저장)
   - DB → Duration
- CustomException 미적용. 추후 수정 예정 

# CheckList
- [x] Commit Convention 준수 여부 확인
- [x] 코드에 대해서 주석 작성 여부 확인
- [x] 불필요 주석, import, Test Log 삭제 여부 확인

# ETC
코드에 대한 설명이나 후처리에 관해 기록할 사항을 적을 것