### PR TITLE
chore: line ending을 통일하기 위한 설정 파일 추가

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+# EditorConfig is awesome: https://editorconfig.org
+
+# top-most EditorConfig file
+root = true
+
+# java 파일은 전부 lf로 끝나게
+[*.java]
+end_of_line = lf
+
+[gradlew]
+end_of_line = lf
+
+[*.bat]
+end_of_line = crlf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
 /gradlew text eol=lf
 *.bat text eol=crlf
 *.jar binary
+*.java text eol=lf


### PR DESCRIPTION
# Work History
- .editorconfig 추가
- .gitattributes 추가

# CheckList
- [x] Commit Convention 준수 여부 확인
- [x] 코드에 대해서 주석 작성 여부 확인
- [x] 불필요 주석, import, Test Log 삭제 여부 확인

# ETC
현재 spotless가 java파일을 lf line ending으로 강제합니다.

하지만 git 은 windows에서 별다른 설정이 없을 시

로컬 <- 원격 : crlf로 변경
로컬 -> 원격 : 다시 lf로 변경

하기 때문에 문제를 일으켰습니다.

이 PR은 그 문제를 해결합니다.