### PR TITLE
feat: 내 쿠폰 전체 조회 및 단건 조회 추가

### DIFF
--- a/src/main/java/com/example/tradedemo/common/consts/ErrorMessage.java
+++ b/src/main/java/com/example/tradedemo/common/consts/ErrorMessage.java
@@ -28,4 +28,5 @@ public final class ErrorMessage {
     public static final String MSG_COUPON_POLICY_FIRST_COME_QUANTITY_REQUIRED = "선착순 쿠폰은 총 수량이 필수입니다";
     public static final String MSG_COUPON_POLICY_AUTO_SIGNUP_ALREADY_EXISTS = "회원가입 자동 발급 쿠폰 정책은 하나만 존재할 수 있습니다";
     public static final String MSG_COUPON_ALREADY_ISSUED = "이미 발급된 쿠폰입니다";
+    public static final String MSG_MEMBER_COUPON_NOT_FOUND = "찾는 쿠폰의 정보가 존재하지 않습니다";
 }

--- a/src/main/java/com/example/tradedemo/common/exception/ErrorEnum.java
+++ b/src/main/java/com/example/tradedemo/common/exception/ErrorEnum.java
@@ -31,7 +31,8 @@ public enum ErrorEnum {
             HttpStatus.BAD_REQUEST, ErrorMessage.MSG_COUPON_POLICY_FIRST_COME_QUANTITY_REQUIRED),
     ERR_COUPON_POLICY_AUTO_SIGNUP_ALREADY_EXISTS(
             HttpStatus.CONFLICT, ErrorMessage.MSG_COUPON_POLICY_AUTO_SIGNUP_ALREADY_EXISTS),
-    ERR_COUPON_ALREADY_ISSUED(HttpStatus.CONFLICT, ErrorMessage.MSG_COUPON_ALREADY_ISSUED);
+    ERR_COUPON_ALREADY_ISSUED(HttpStatus.CONFLICT, ErrorMessage.MSG_COUPON_ALREADY_ISSUED),
+    ERR_MEMBER_COUPON_NOT_FOUND(HttpStatus.NOT_FOUND, ErrorMessage.MSG_MEMBER_COUPON_NOT_FOUND);
 
     private final HttpStatus httpStatus;
     private final String errorMessage;

--- a/src/main/java/com/example/tradedemo/domain/coupon/controller/CouponController.java
+++ b/src/main/java/com/example/tradedemo/domain/coupon/controller/CouponController.java
@@ -1,10 +1,12 @@
 package com.example.tradedemo.domain.coupon.controller;
 
+import com.example.tradedemo.auth.dto.PrincipalDetails;
 import com.example.tradedemo.common.dto.ApiResponse;
 import com.example.tradedemo.common.dto.PageResponse;
 import com.example.tradedemo.domain.coupon.dto.CreateCouponPolicyRequest;
 import com.example.tradedemo.domain.coupon.dto.CreateCouponPolicyResponse;
 import com.example.tradedemo.domain.coupon.dto.SearchAllCouponPolicyResponse;
+import com.example.tradedemo.domain.coupon.dto.SearchAllMemberCouponResponse;
 import com.example.tradedemo.domain.coupon.service.CouponService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -12,6 +14,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -43,6 +46,32 @@ public class CouponController {
 
         PageResponse<SearchAllCouponPolicyResponse> response =
                 PageResponse.of(couponService.searchAllCouponPolicies(sortCreatedAt, issueType, pageable));
+
+        return ResponseEntity.ok(ApiResponse.success(String.valueOf(HttpStatus.OK.value()), response));
+    }
+
+    // 내 쿠폰 전체 조회 (페이징)
+    @GetMapping("/api/v1/me/coupons")
+    public ResponseEntity<ApiResponse<PageResponse<SearchAllMemberCouponResponse>>> getAllMemberCoupon(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(required = false) String status,
+            @AuthenticationPrincipal PrincipalDetails principalDetails) {
+
+        Pageable pageable = PageRequest.of(page, 10);
+        Long memberId = principalDetails.getMember().getId();
+        PageResponse<SearchAllMemberCouponResponse> response =
+                PageResponse.of(couponService.getAllMemberCoupon(memberId, status, pageable));
+
+        return ResponseEntity.ok(ApiResponse.success(String.valueOf(HttpStatus.OK.value()), response));
+    }
+
+    @GetMapping("/api/v1/me/coupons/{couponId}")
+    public ResponseEntity<ApiResponse<SearchAllMemberCouponResponse>> getMemberCoupon(
+            @PathVariable Long couponId, @AuthenticationPrincipal PrincipalDetails principalDetails) {
+
+        Long memberId = principalDetails.getMember().getId();
+
+        SearchAllMemberCouponResponse response = couponService.getMemberCoupon(memberId, couponId);
 
         return ResponseEntity.ok(ApiResponse.success(String.valueOf(HttpStatus.OK.value()), response));
     }

--- a/src/main/java/com/example/tradedemo/domain/coupon/dto/SearchAllMemberCouponResponse.java
+++ b/src/main/java/com/example/tradedemo/domain/coupon/dto/SearchAllMemberCouponResponse.java
@@ -1,0 +1,68 @@
+package com.example.tradedemo.domain.coupon.dto;
+
+import com.example.tradedemo.common.dto.DurationResponse;
+import com.example.tradedemo.domain.coupon.entity.MemberCoupon;
+import com.example.tradedemo.domain.coupon.enums.CouponStatus;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import lombok.Getter;
+
+@Getter
+@JsonPropertyOrder({
+    "memberCouponId",
+    "couponName",
+    "moneyAmount",
+    "status",
+    "couponDuration",
+    "issuedAt",
+    "expiredAt",
+    "createdAt",
+    "modifiedAt"
+})
+public class SearchAllMemberCouponResponse {
+
+    private final Long memberCouponId;
+    private final String couponName;
+    private final BigDecimal moneyAmount;
+    private final CouponStatus status;
+    private final DurationResponse couponDuration;
+    private final LocalDateTime issuedAt;
+    private final LocalDateTime expiredAt;
+    private final LocalDateTime createdAt;
+    private final LocalDateTime modifiedAt;
+
+    private SearchAllMemberCouponResponse(
+            Long memberCouponId,
+            String couponName,
+            BigDecimal moneyAmount,
+            CouponStatus status,
+            DurationResponse couponDuration,
+            LocalDateTime issuedAt,
+            LocalDateTime expiredAt,
+            LocalDateTime createdAt,
+            LocalDateTime modifiedAt) {
+        this.memberCouponId = memberCouponId;
+        this.couponName = couponName;
+        this.moneyAmount = moneyAmount;
+        this.status = status;
+        this.couponDuration = couponDuration;
+        this.issuedAt = issuedAt;
+        this.expiredAt = expiredAt;
+        this.createdAt = createdAt;
+        this.modifiedAt = modifiedAt;
+    }
+
+    public static SearchAllMemberCouponResponse of(MemberCoupon memberCoupon) {
+        return new SearchAllMemberCouponResponse(
+                memberCoupon.getId(),
+                memberCoupon.getCouponPolicy().getName(),
+                memberCoupon.getCouponPolicy().getMoneyAmount(),
+                memberCoupon.getStatus(),
+                DurationResponse.of(memberCoupon.getCouponPolicy().getCouponDuration()),
+                memberCoupon.getIssuedAt(),
+                memberCoupon.getExpiredAt(),
+                memberCoupon.getCreatedAt(),
+                memberCoupon.getModifiedAt());
+    }
+}

--- a/src/main/java/com/example/tradedemo/domain/coupon/repository/MemberCouponCustomRepository.java
+++ b/src/main/java/com/example/tradedemo/domain/coupon/repository/MemberCouponCustomRepository.java
@@ -1,0 +1,13 @@
+package com.example.tradedemo.domain.coupon.repository;
+
+import com.example.tradedemo.domain.coupon.dto.SearchAllMemberCouponResponse;
+import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface MemberCouponCustomRepository {
+
+    Page<SearchAllMemberCouponResponse> findAllMemberCouponByMemberId(Long memberId, String status, Pageable pageable);
+
+    Optional<SearchAllMemberCouponResponse> findMemberCouponByMemberIdAndMemberCouponId(Long memberId, Long couponId);
+}

--- a/src/main/java/com/example/tradedemo/domain/coupon/repository/MemberCouponCustomRepositoryImpl.java
+++ b/src/main/java/com/example/tradedemo/domain/coupon/repository/MemberCouponCustomRepositoryImpl.java
@@ -1,0 +1,71 @@
+package com.example.tradedemo.domain.coupon.repository;
+
+import static com.example.tradedemo.domain.coupon.entity.QCouponPolicy.couponPolicy;
+import static com.example.tradedemo.domain.coupon.entity.QMemberCoupon.memberCoupon;
+
+import com.example.tradedemo.domain.coupon.dto.SearchAllMemberCouponResponse;
+import com.example.tradedemo.domain.coupon.entity.MemberCoupon;
+import com.example.tradedemo.domain.coupon.enums.CouponStatus;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+@RequiredArgsConstructor
+public class MemberCouponCustomRepositoryImpl implements MemberCouponCustomRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<SearchAllMemberCouponResponse> findAllMemberCouponByMemberId(
+            Long memberId, String status, Pageable pageable) {
+
+        BooleanBuilder builder = new BooleanBuilder();
+        builder.and(memberCoupon.member.id.eq(memberId));
+
+        // status 필터
+        if (status != null && !status.isBlank()) {
+            try {
+                builder.and(memberCoupon.status.eq(CouponStatus.valueOf(status)));
+            } catch (IllegalArgumentException ignored) {
+            }
+        }
+
+        List<MemberCoupon> content = queryFactory
+                .selectFrom(memberCoupon)
+                .join(memberCoupon.couponPolicy, couponPolicy)
+                .fetchJoin()
+                .where(builder)
+                .orderBy(memberCoupon.createdAt.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        Long total = queryFactory
+                .select(memberCoupon.count())
+                .from(memberCoupon)
+                .where(builder)
+                .fetchOne();
+
+        return new PageImpl<>(
+                content.stream().map(SearchAllMemberCouponResponse::of).toList(), pageable, total == null ? 0 : total);
+    }
+
+    @Override
+    public Optional<SearchAllMemberCouponResponse> findMemberCouponByMemberIdAndMemberCouponId(
+            Long memberId, Long couponId) {
+
+        MemberCoupon result = queryFactory
+                .selectFrom(memberCoupon)
+                .join(memberCoupon.couponPolicy, couponPolicy)
+                .fetchJoin()
+                .where(memberCoupon.member.id.eq(memberId), memberCoupon.id.eq(couponId))
+                .fetchOne();
+
+        return Optional.ofNullable(result).map(SearchAllMemberCouponResponse::of);
+    }
+}

--- a/src/main/java/com/example/tradedemo/domain/coupon/repository/MemberCouponRepository.java
+++ b/src/main/java/com/example/tradedemo/domain/coupon/repository/MemberCouponRepository.java
@@ -5,7 +5,7 @@ import com.example.tradedemo.domain.coupon.entity.MemberCoupon;
 import com.example.tradedemo.domain.members.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface MemberCouponRepository extends JpaRepository<MemberCoupon, Long> {
+public interface MemberCouponRepository extends JpaRepository<MemberCoupon, Long>, MemberCouponCustomRepository {
     // 중복 발급 방지 체크
     boolean existsByMemberAndCouponPolicy(Member member, CouponPolicy couponPolicy);
 }

--- a/src/main/java/com/example/tradedemo/domain/coupon/service/CouponService.java
+++ b/src/main/java/com/example/tradedemo/domain/coupon/service/CouponService.java
@@ -6,6 +6,7 @@ import com.example.tradedemo.domain.coupon.constants.CouponDuration;
 import com.example.tradedemo.domain.coupon.dto.CreateCouponPolicyRequest;
 import com.example.tradedemo.domain.coupon.dto.CreateCouponPolicyResponse;
 import com.example.tradedemo.domain.coupon.dto.SearchAllCouponPolicyResponse;
+import com.example.tradedemo.domain.coupon.dto.SearchAllMemberCouponResponse;
 import com.example.tradedemo.domain.coupon.entity.CouponPolicy;
 import com.example.tradedemo.domain.coupon.entity.MemberCoupon;
 import com.example.tradedemo.domain.coupon.enums.IssueType;
@@ -106,5 +107,17 @@ public class CouponService {
     public Page<SearchAllCouponPolicyResponse> searchAllCouponPolicies(
             String sortCreatedAt, String issueType, Pageable pageable) {
         return couponPolicyRepository.getAllCouponPolicy(sortCreatedAt, issueType, pageable);
+    }
+
+    @Transactional(readOnly = true)
+    public Page<SearchAllMemberCouponResponse> getAllMemberCoupon(Long memberId, String status, Pageable pageable) {
+        return memberCouponRepository.findAllMemberCouponByMemberId(memberId, status, pageable);
+    }
+
+    @Transactional(readOnly = true)
+    public SearchAllMemberCouponResponse getMemberCoupon(Long memberId, Long couponId) {
+        return memberCouponRepository
+                .findMemberCouponByMemberIdAndMemberCouponId(memberId, couponId)
+                .orElseThrow(() -> new ServiceException(ErrorEnum.ERR_MEMBER_COUPON_NOT_FOUND));
     }
 }


### PR DESCRIPTION
# Work History
- 내 쿠폰 전체 조회 기능 추가
   - 페이징 처리 
   - 미사용, 사용, 만료 상태의 쿠폰 모두 조회 가능
   - 쿠폰 상태별 조회 가능 (UNUSED, USED, EXPIRED)
   - -> 추후 전체 조회 시에 UNUSED, USED, EXPIRED 순으로 미사용된 쿠폰 먼저 상단에 조회되게 할 예정

- 내 쿠폰 단건 조회 기능 추가

# CheckList
- [x] Commit Convention 준수 여부 확인
- [x] 코드에 대해서 주석 작성 여부 확인
- [x] 불필요 주석, import, Test Log 삭제 여부 확인

# ETC
- 내 쿠폰 전체 조회 기능 추가
   -> 추후 전체 조회 시에 UNUSED, USED, EXPIRED 순으로 미사용된 쿠폰 먼저 상단에 조회되게 할 예정