### PR TITLE
feat: 동일 유저 인기 검색어 어뷰징 방지 기능 추가

### DIFF
--- a/src/main/java/com/example/tradedemo/common/consts/RedisConsts.java
+++ b/src/main/java/com/example/tradedemo/common/consts/RedisConsts.java
@@ -12,6 +12,7 @@ public final class RedisConsts {
     public static final String TRENDING_PREFIX_KEYWORD = "trending:prefix:";
 
     // config
+    public static final Long SEARCH_DUPLICATE_PREVENT_MINUTES = 15L;
     public static final Long TRENDING_KEYWORD_TIME_LIMIT = 2L;
     public static final int TRENDING_SEARCH_LIMIT = 5;
     public static final DateTimeFormatter TRENDING_SEARCH_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd");

--- a/src/main/java/com/example/tradedemo/domain/marketlistings/consts/MarketListingConsts.java
+++ b/src/main/java/com/example/tradedemo/domain/marketlistings/consts/MarketListingConsts.java
@@ -1,9 +1,8 @@
-package com.example.tradedemo.common.consts;
+package com.example.tradedemo.domain.marketlistings.consts;
 
 import java.time.format.DateTimeFormatter;
 
-public final class RedisConsts {
-
+public final class MarketListingConsts {
     // domain
     public static final String MARKET_LISTING = "listing:";
 

--- a/src/main/java/com/example/tradedemo/domain/marketlistings/controller/MarketListingController.java
+++ b/src/main/java/com/example/tradedemo/domain/marketlistings/controller/MarketListingController.java
@@ -30,7 +30,7 @@ public class MarketListingController {
      *  asc/desc 가 아닌 값 전달 시 정렬 조건에서 무시 (예외 처리 x)
      */
     @GetMapping("/api/v1/me/market-listings")
-    public ResponseEntity<ApiResponse<Page<SearchAllMarketListingResponse>>> getAllMarketListing(
+    public ResponseEntity<ApiResponse<Page<SearchAllMarketListingResponse>>> getAllMeMarketListing(
             @AuthenticationPrincipal PrincipalDetails details,
             @RequestParam(required = false) String keyword,
             @RequestParam(required = false) String sortTotalPrice,
@@ -52,6 +52,7 @@ public class MarketListingController {
      */
     @GetMapping("/api/v1/market-listings")
     public ResponseEntity<ApiResponse<Page<SearchAllMarketListingResponse>>> getAllMarketListing(
+            @AuthenticationPrincipal PrincipalDetails details,
             @RequestParam(required = false) String keyword,
             @RequestParam(required = false) String sortTotalPrice,
             @RequestParam(required = false) String sortSaleEndAt,
@@ -61,7 +62,8 @@ public class MarketListingController {
 
         return ResponseEntity.ok(ApiResponse.success(
                 String.valueOf(HttpStatus.OK.value()),
-                marketListingService.getAllMarketListing(keyword, sortTotalPrice, sortSaleEndAt, pageable)));
+                marketListingService.getAllMarketListing(
+                        details.getMember().getId(), keyword, sortTotalPrice, sortSaleEndAt, pageable)));
     }
 
     /**

--- a/src/main/java/com/example/tradedemo/domain/marketlistings/service/MarketListingCacheService.java
+++ b/src/main/java/com/example/tradedemo/domain/marketlistings/service/MarketListingCacheService.java
@@ -1,6 +1,6 @@
 package com.example.tradedemo.domain.marketlistings.service;
 
-import com.example.tradedemo.common.consts.RedisConsts;
+import com.example.tradedemo.domain.marketlistings.consts.MarketListingConsts;
 import com.example.tradedemo.domain.marketlistings.dto.response.SearchTrendingKeywordResponse;
 import java.time.Duration;
 import java.time.LocalDate;
@@ -41,13 +41,13 @@ public class MarketListingCacheService {
         /**
          * 동일 검색어 어뷰징 방지용
          */
-        String dupCheckKey = RedisConsts.MARKET_LISTING + memberId + ":" + normalizedKeyword;
+        String dupCheckKey = MarketListingConsts.MARKET_LISTING + memberId + ":" + normalizedKeyword;
         Boolean firstSearch = redisTemplate
                 .opsForValue()
                 .setIfAbsent(
                         dupCheckKey,
                         normalizedKeyword,
-                        Duration.ofMinutes(RedisConsts.SEARCH_DUPLICATE_PREVENT_MINUTES));
+                        Duration.ofMinutes(MarketListingConsts.SEARCH_DUPLICATE_PREVENT_MINUTES));
 
         if (!firstSearch) {
             return;
@@ -64,11 +64,11 @@ public class MarketListingCacheService {
         Long prefixTtl = redisTemplate.getExpire(prefixKey);
 
         if (ttl == null || ttl <= 0) {
-            redisTemplate.expire(key, Duration.ofDays(RedisConsts.TRENDING_KEYWORD_TIME_LIMIT));
+            redisTemplate.expire(key, Duration.ofDays(MarketListingConsts.TRENDING_KEYWORD_TIME_LIMIT));
         }
 
         if (prefixTtl == null || prefixTtl <= 0) {
-            redisTemplate.expire(prefixKey, Duration.ofDays(RedisConsts.TRENDING_KEYWORD_TIME_LIMIT));
+            redisTemplate.expire(prefixKey, Duration.ofDays(MarketListingConsts.TRENDING_KEYWORD_TIME_LIMIT));
         }
     }
 
@@ -76,7 +76,7 @@ public class MarketListingCacheService {
         String key = getTrendingKey();
 
         Set<ZSetOperations.TypedTuple<String>> trendingKeywords =
-                redisTemplate.opsForZSet().reverseRangeWithScores(key, 0, RedisConsts.TRENDING_SEARCH_LIMIT - 1);
+                redisTemplate.opsForZSet().reverseRangeWithScores(key, 0, MarketListingConsts.TRENDING_SEARCH_LIMIT - 1);
 
         return trendingKeywords.stream()
                 .map(t -> SearchTrendingKeywordResponse.create(
@@ -110,19 +110,19 @@ public class MarketListingCacheService {
                 })
                 .sorted(Comparator.comparing(SearchTrendingKeywordResponse::getSearchCount)
                         .reversed())
-                .limit(RedisConsts.TRENDING_SEARCH_LIMIT)
+                .limit(MarketListingConsts.TRENDING_SEARCH_LIMIT)
                 .toList();
     }
 
     private String getTrendingKey() {
-        return RedisConsts.MARKET_LISTING
-                + RedisConsts.TRENDING_SEARCH
-                + LocalDate.now().format(RedisConsts.TRENDING_SEARCH_FORMATTER);
+        return MarketListingConsts.MARKET_LISTING
+                + MarketListingConsts.TRENDING_SEARCH
+                + LocalDate.now().format(MarketListingConsts.TRENDING_SEARCH_FORMATTER);
     }
 
     private String getPrefixKey() {
-        return RedisConsts.MARKET_LISTING
-                + RedisConsts.TRENDING_PREFIX_KEYWORD
-                + LocalDate.now().format(RedisConsts.TRENDING_SEARCH_FORMATTER);
+        return MarketListingConsts.MARKET_LISTING
+                + MarketListingConsts.TRENDING_PREFIX_KEYWORD
+                + LocalDate.now().format(MarketListingConsts.TRENDING_SEARCH_FORMATTER);
     }
 }

--- a/src/main/java/com/example/tradedemo/domain/marketlistings/service/MarketListingCacheService.java
+++ b/src/main/java/com/example/tradedemo/domain/marketlistings/service/MarketListingCacheService.java
@@ -18,7 +18,7 @@ import org.springframework.stereotype.Service;
 public class MarketListingCacheService {
     private final RedisTemplate<String, String> redisTemplate;
 
-    public void cacheSearchKeyword(String keyword) {
+    public void cacheSearchKeyword(Long memberId, String keyword) {
 
         if (keyword == null || keyword.isBlank()) {
             return;
@@ -37,6 +37,21 @@ public class MarketListingCacheService {
          * 언어 종류에 영향을 받지 않도록 locale 지정
          */
         String normalizedKeyword = keyword.trim().replaceAll("\\s+", " ").toLowerCase(Locale.ROOT);
+
+        /**
+         * 동일 검색어 어뷰징 방지용
+         */
+        String dupCheckKey = RedisConsts.MARKET_LISTING + memberId + ":" + normalizedKeyword;
+        Boolean firstSearch = redisTemplate
+                .opsForValue()
+                .setIfAbsent(
+                        dupCheckKey,
+                        normalizedKeyword,
+                        Duration.ofMinutes(RedisConsts.SEARCH_DUPLICATE_PREVENT_MINUTES));
+
+        if (!firstSearch) {
+            return;
+        }
 
         /**
          *  똑같은 keyword를 서로 다른 키에 저장

--- a/src/main/java/com/example/tradedemo/domain/marketlistings/service/MarketListingCacheService.java
+++ b/src/main/java/com/example/tradedemo/domain/marketlistings/service/MarketListingCacheService.java
@@ -75,8 +75,9 @@ public class MarketListingCacheService {
     public List<SearchTrendingKeywordResponse> getTrendingKeywordList() {
         String key = getTrendingKey();
 
-        Set<ZSetOperations.TypedTuple<String>> trendingKeywords =
-                redisTemplate.opsForZSet().reverseRangeWithScores(key, 0, MarketListingConsts.TRENDING_SEARCH_LIMIT - 1);
+        Set<ZSetOperations.TypedTuple<String>> trendingKeywords = redisTemplate
+                .opsForZSet()
+                .reverseRangeWithScores(key, 0, MarketListingConsts.TRENDING_SEARCH_LIMIT - 1);
 
         return trendingKeywords.stream()
                 .map(t -> SearchTrendingKeywordResponse.create(

--- a/src/main/java/com/example/tradedemo/domain/marketlistings/service/MarketListingService.java
+++ b/src/main/java/com/example/tradedemo/domain/marketlistings/service/MarketListingService.java
@@ -22,9 +22,9 @@ public class MarketListingService {
 
     @Transactional(readOnly = true)
     public Page<SearchAllMarketListingResponse> getAllMarketListing(
-            String keyword, String sortTotalPrice, String sortSaleEndAt, Pageable pageable) {
+            Long memberId, String keyword, String sortTotalPrice, String sortSaleEndAt, Pageable pageable) {
         if (keyword != null && !keyword.isBlank()) {
-            marketListingCacheService.cacheSearchKeyword(keyword);
+            marketListingCacheService.cacheSearchKeyword(memberId, keyword);
         }
 
         return marketListingRepository.getAllMarketListingWithKeyword(


### PR DESCRIPTION
# Work History
작업 내역 적기
- 동일 유저가 반복해서 인기 검색어 카운팅을 늘리는 것을 방지 (15분에 한번만 가능)
- 검색어 캐싱 과정에서 유저id+키워드로 구성된 키를 사용하여 구현

# CheckList
- [ ] Commit Convention 준수 여부 확인
- [ ] 코드에 대해서 주석 작성 여부 확인
- [ ] 불필요 주석, import, Test Log 삭제 여부 확인

# ETC
코드에 대한 설명이나 후처리에 관해 기록할 사항을 적을 것