### PR TITLE
chore: CI에서 포맷 확인 제거

### DIFF
--- a/.github/workflows/sanity-check.yml
+++ b/.github/workflows/sanity-check.yml
@@ -30,4 +30,4 @@ jobs:
       - name: check build and formatting
         run: |
           chmod +x gradlew
-          ./gradlew spotlessCheck build --no-daemon -x test
+          ./gradlew build --no-daemon -x test -x spotlessCheck


### PR DESCRIPTION
# Work History
- CI에서 포맷 확인을 제거했습니다.

# CheckList
- [x] Commit Convention 준수 여부 확인
- [x] 코드에 대해서 주석 작성 여부 확인
- [x] 불필요 주석, import, Test Log 삭제 여부 확인

# ETC
일단 spotless의 의존성 자체는 제거하지 않고 CI테스트 동안 build가 되는지만 테스트 하도록 수정하였습니다.