### PR TITLE
feat: 쿠폰 정책 생성 시 관리자가 기간 설정 가능하게 추가

### DIFF
--- a/src/main/java/com/example/tradedemo/domain/coupon/constants/CouponDuration.java
+++ b/src/main/java/com/example/tradedemo/domain/coupon/constants/CouponDuration.java
@@ -1,5 +1,6 @@
 package com.example.tradedemo.domain.coupon.constants;
 
+import com.example.tradedemo.domain.coupon.dto.DurationRequest;
 import com.example.tradedemo.domain.coupon.enums.IssueType;
 import java.time.Duration;
 
@@ -14,14 +15,20 @@ public final class CouponDuration {
 
     private CouponDuration() {}
 
-    public static Duration getPolicyDuration(IssueType issueType) {
+    public static Duration getPolicyDuration(IssueType issueType, DurationRequest policyDuration) {
+        if (policyDuration != null) {
+            return Duration.ofSeconds(policyDuration.toSeconds());
+        }
         return switch (issueType) {
             case FIRST_COME -> FIRST_COME_POLICY;
             case AUTO_SIGNUP -> null; // 정책 만료 없음
         };
     }
 
-    public static Duration getCouponDuration(IssueType issueType) {
+    public static Duration getCouponDuration(IssueType issueType, DurationRequest couponDuration) {
+        if (couponDuration != null) {
+            return Duration.ofSeconds(couponDuration.toSeconds());
+        }
         return switch (issueType) {
             case FIRST_COME -> FIRST_COME_COUPON;
             case AUTO_SIGNUP -> AUTO_SIGNUP_COUPON; // null (무제한)

--- a/src/main/java/com/example/tradedemo/domain/coupon/dto/CreateCouponPolicyRequest.java
+++ b/src/main/java/com/example/tradedemo/domain/coupon/dto/CreateCouponPolicyRequest.java
@@ -24,20 +24,28 @@ public class CreateCouponPolicyRequest {
     // FIRST_COME 이면 필수, AUTO_SIGNUP 이면 null
     private final Long totalQuantity;
 
+    // null이면 상수 기본값 사용
+    private final DurationRequest policyDuration;
+    private final DurationRequest couponDuration;
+
     @JsonCreator
     private CreateCouponPolicyRequest(
             @JsonProperty("name") String name,
             @JsonProperty("moneyAmount") BigDecimal moneyAmount,
             @JsonProperty("issueType") IssueType issueType,
-            @JsonProperty("totalQuantity") Long totalQuantity) {
+            @JsonProperty("totalQuantity") Long totalQuantity,
+            @JsonProperty("policyDuration") DurationRequest policyDuration,
+            @JsonProperty("couponDuration") DurationRequest couponDuration) {
         this.name = name;
         this.moneyAmount = moneyAmount;
         this.issueType = issueType;
         this.totalQuantity = totalQuantity;
+        this.policyDuration = policyDuration;
+        this.couponDuration = couponDuration;
     }
 
     public static CreateCouponPolicyRequest of(
-            String name, BigDecimal moneyAmount, IssueType issueType, Long totalQuantity) {
-        return new CreateCouponPolicyRequest(name, moneyAmount, issueType, totalQuantity);
+            String name, BigDecimal moneyAmount, IssueType issueType, Long totalQuantity, DurationRequest policyDuration, DurationRequest couponDuration) {
+        return new CreateCouponPolicyRequest(name, moneyAmount, issueType, totalQuantity, policyDuration, couponDuration);
     }
 }

--- a/src/main/java/com/example/tradedemo/domain/coupon/dto/DurationRequest.java
+++ b/src/main/java/com/example/tradedemo/domain/coupon/dto/DurationRequest.java
@@ -1,0 +1,31 @@
+package com.example.tradedemo.domain.coupon.dto;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+@Getter
+public class DurationRequest {
+
+    private final long days;
+    private final long hours;
+    private final long minutes;
+    private final long seconds;
+
+    @JsonCreator
+    public DurationRequest(
+            @JsonProperty("days") long days,
+            @JsonProperty("hours") long hours,
+            @JsonProperty("minutes") long minutes,
+            @JsonProperty("seconds") long seconds) {
+        this.days = days;
+        this.hours = hours;
+        this.minutes = minutes;
+        this.seconds = seconds;
+    }
+
+    // 초 단위로 합산
+    public long toSeconds() {
+        return (days * 86400) + (hours * 3600) + (minutes * 60) + seconds;
+    }
+}

--- a/src/main/java/com/example/tradedemo/domain/coupon/service/CouponService.java
+++ b/src/main/java/com/example/tradedemo/domain/coupon/service/CouponService.java
@@ -61,8 +61,8 @@ public class CouponService {
         LocalDateTime policyStartedAt = LocalDateTime.now();
 
         // IssueType 에 따라 상수에서 Duration 자동 선택
-        Duration policyDuration = CouponDuration.getPolicyDuration(request.getIssueType());
-        Duration couponDuration = CouponDuration.getCouponDuration(request.getIssueType());
+        Duration policyDuration = CouponDuration.getPolicyDuration(request.getIssueType(), request.getPolicyDuration());
+        Duration couponDuration = CouponDuration.getCouponDuration(request.getIssueType(), request.getCouponDuration());
 
         // 정책 만료일 = 시작일 + policyDuration (AUTO_SIGNUP 이면 null)
         LocalDateTime policyExpiredAt = policyDuration != null ? policyStartedAt.plus(policyDuration) : null;


### PR DESCRIPTION
# Work History
- 쿠폰 정책 생성 시 관리자가 기간 설정 가능하게 추가
   - 일/시/분/초 각각 입력 후 요청 시 초 단위로 합산해 DB에 저장
   - 관리자가 유효 기간을 유동적으로 쿠폰 정책 생성 가능
      - 5일 15시간 30분 30초 짜리의 쿠폰 등
- 정책 유효기간, 쿠폰 유효기간 입력 시 -> 입력한 기간으로 쿠폰 정책 생성
- 정책 유효기간, 쿠폰 유효기간 미입력 시 -> 상수로 설정해둔 기본값으로 쿠폰 정책 생성
- DurationRequest Dto 생성

# CheckList
- [x] Commit Convention 준수 여부 확인
- [x] 코드에 대해서 주석 작성 여부 확인
- [x] 불필요 주석, import, Test Log 삭제 여부 확인
