### PR TITLE
fix: 쿠폰 만료 스케줄러 상태 변경 forEach 사용

### DIFF
--- a/src/main/java/com/example/tradedemo/domain/coupon/scheduler/CouponExpiryScheduler.java
+++ b/src/main/java/com/example/tradedemo/domain/coupon/scheduler/CouponExpiryScheduler.java
@@ -36,8 +36,9 @@ public class CouponExpiryScheduler {
             return;
         }
 
+        expiredCoupons.forEach(MemberCoupon::updateExpireStatus);
+
         List<CouponHistory> histories = expiredCoupons.stream()
-                .peek(MemberCoupon::updateExpireStatus)
                 .map(mc -> CouponHistory.createExpired(mc.getMember(), mc))
                 .toList();
 


### PR DESCRIPTION
# Work History
- 쿠폰 만료 스케줄러 상태 변경 시 peek 사용 -> forEach 사용
- stream peek은 디버깅용이기 때문에 쿠폰 상태를 바꾸는 것과 쿠폰 히스토리를 만들어 저장하는 것은 분리되어야함.

# CheckList
- [x] Commit Convention 준수 여부 확인
- [x] 코드에 대해서 주석 작성 여부 확인
- [x] 불필요 주석, import, Test Log 삭제 여부 확인
