### PR TITLE
refactor: order 도메인에 facade 레이어 추가, 상품 구매 코드 개선

### DIFF
--- a/src/main/java/com/example/tradedemo/domain/marketlistings/entity/MarketListing.java
+++ b/src/main/java/com/example/tradedemo/domain/marketlistings/entity/MarketListing.java
@@ -1,6 +1,8 @@
 package com.example.tradedemo.domain.marketlistings.entity;
 
 import com.example.tradedemo.common.entity.Base;
+import com.example.tradedemo.common.exception.ErrorEnum;
+import com.example.tradedemo.common.exception.ServiceException;
 import com.example.tradedemo.domain.marketlistings.enums.MarketListingStatus;
 import com.example.tradedemo.domain.members.entity.Member;
 import com.example.tradedemo.domain.members.entity.MemberItem;
@@ -101,5 +103,11 @@ public class MarketListing extends Base {
      */
     public void updateStatus(MarketListingStatus newStatus) {
         this.status = newStatus;
+    }
+
+    public void validateSelling(){
+        if (this.getStatus() != MarketListingStatus.SELLING) {
+            throw new ServiceException(ErrorEnum.ERR_MARKET_LISTING_NOT_SELLING);
+        }
     }
 }

--- a/src/main/java/com/example/tradedemo/domain/marketlistings/service/MarketListingService.java
+++ b/src/main/java/com/example/tradedemo/domain/marketlistings/service/MarketListingService.java
@@ -44,8 +44,6 @@ public class MarketListingService {
     private final MemberRepository memberRepository;
     private final MarketListingCacheService marketListingCacheService;
     private final PendingAssetRepository pendingAssetRepository;
-    private final WalletRepository walletRepository;
-    private final WalletHistoryRepository walletHistoryRepository;
 
     /**
      * 상품 등록
@@ -317,5 +315,12 @@ public class MarketListingService {
     @Transactional
     public SearchMarketListingResponse cancelMarketListingAdmin(PrincipalDetails details, Long marketListingId) {
         return cancelMarketListingImpl(details, true, marketListingId);
+    }
+
+    @Transactional(readOnly = true)
+    public MarketListing findMarketListing(Long marketListingId) {
+        return marketListingRepository.findById(marketListingId).orElseThrow(
+                () -> new ServiceException(ErrorEnum.ERR_MARKET_LISTING_NOT_FOUND)
+        );
     }
 }

--- a/src/main/java/com/example/tradedemo/domain/members/service/MemberService.java
+++ b/src/main/java/com/example/tradedemo/domain/members/service/MemberService.java
@@ -194,4 +194,10 @@ public class MemberService {
 
         member.suspend(request.reason());
     }
+
+    @Transactional(readOnly = true)
+    public Member findMember(Long memberId) {
+
+        return memberRepository.findById(memberId).orElseThrow(() -> new ServiceException(ErrorEnum.ERR_MEMBER_NOT_FOUND));
+    }
 }

--- a/src/main/java/com/example/tradedemo/domain/order/controller/OrderController.java
+++ b/src/main/java/com/example/tradedemo/domain/order/controller/OrderController.java
@@ -4,6 +4,7 @@ import com.example.tradedemo.auth.dto.PrincipalDetails;
 import com.example.tradedemo.common.dto.ApiResponse;
 import com.example.tradedemo.domain.order.dto.CreateOrderResponse;
 import com.example.tradedemo.domain.order.dto.GetTransactionResponse;
+import com.example.tradedemo.domain.order.facade.OrderFacade;
 import com.example.tradedemo.domain.order.service.OrderService;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -18,6 +19,7 @@ import org.springframework.web.bind.annotation.*;
 public class OrderController {
 
     private final OrderService orderService;
+    private final OrderFacade orderFacade;
 
     /**
      * 상품 구매
@@ -26,7 +28,7 @@ public class OrderController {
     public void purchase(
             @PathVariable Long marketListingId, @AuthenticationPrincipal PrincipalDetails principalDetails) {
         Long memberId = principalDetails.getMember().getId();
-        orderService.purchase(memberId, marketListingId);
+        orderFacade.purchase(memberId, marketListingId);
     }
 
     @PostMapping("/v2/market-listings/{marketListingId}")
@@ -34,7 +36,7 @@ public class OrderController {
             @PathVariable Long marketListingId, @AuthenticationPrincipal PrincipalDetails principalDetails) {
         Long memberId = principalDetails.getMember().getId();
         return ResponseEntity.ok(
-                ApiResponse.success(String.valueOf(HttpStatus.OK), orderService.purchaseV2(memberId, marketListingId)));
+                ApiResponse.success(String.valueOf(HttpStatus.OK), orderFacade.purchaseV2(memberId, marketListingId)));
     }
 
     /**

--- a/src/main/java/com/example/tradedemo/domain/order/facade/OrderFacade.java
+++ b/src/main/java/com/example/tradedemo/domain/order/facade/OrderFacade.java
@@ -1,0 +1,84 @@
+package com.example.tradedemo.domain.order.facade;
+
+
+import com.example.tradedemo.common.exception.ErrorEnum;
+import com.example.tradedemo.common.exception.ServiceException;
+import com.example.tradedemo.domain.marketlistings.entity.MarketListing;
+import com.example.tradedemo.domain.marketlistings.enums.MarketListingStatus;
+import com.example.tradedemo.domain.marketlistings.service.MarketListingService;
+import com.example.tradedemo.domain.members.entity.Member;
+import com.example.tradedemo.domain.members.service.MemberService;
+import com.example.tradedemo.domain.order.dto.CreateOrderResponse;
+import com.example.tradedemo.domain.order.entity.Order;
+import com.example.tradedemo.domain.order.service.OrderService;
+import com.example.tradedemo.domain.pending.entity.PendingAsset;
+import com.example.tradedemo.domain.pending.enums.PendingType;
+import com.example.tradedemo.domain.pending.enums.Type;
+import com.example.tradedemo.domain.pending.service.PendingAssetService;
+import com.example.tradedemo.domain.wallet.entity.Wallet;
+import com.example.tradedemo.domain.wallet.entity.WalletHistories;
+import com.example.tradedemo.domain.wallet.enums.WalletStatus;
+import com.example.tradedemo.domain.wallet.repository.WalletHistoryRepository;
+import com.example.tradedemo.domain.wallet.service.WalletService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Caching;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Component
+@RequiredArgsConstructor
+public class OrderFacade {
+    
+    private final OrderService orderService;
+    private final WalletService walletService;
+    private final MemberService memberService;
+    private final PendingAssetService pendingAssetService;
+    private final MarketListingService marketListingService;
+
+    @Transactional
+    public void purchase(Long buyerId, Long marketListingId) {
+
+        Member buyer = memberService.findMember(buyerId);
+        Wallet wallet = walletService.findWallet(buyerId);
+        MarketListing marketListing = marketListingService.findMarketListing(marketListingId);
+
+        marketListing.validateSelling();
+        wallet.checkBalanceAvailable(marketListing.getTotalPrice());
+
+        Order order = orderService.createOrder(buyer, marketListing);
+
+        walletService.payForOrder(wallet, marketListing, order);
+        pendingAssetService.createTradePendingAsset(marketListing, order, buyer);
+
+        marketListing.updateStatus(MarketListingStatus.SOLD);
+    }
+
+
+    @Transactional
+    @Caching(evict = {
+            @CacheEvict(cacheNames = "marketListingsFirstPage", allEntries = true),
+            @CacheEvict(cacheNames = "marketListingItem", key = "'listing:' + #marketListingId")
+    })
+    public CreateOrderResponse purchaseV2(Long buyerId, Long marketListingId) {
+
+        Member buyer = memberService.findMember(buyerId);
+        Wallet wallet = walletService.findWallet(buyerId);
+        MarketListing marketListing = marketListingService.findMarketListing(marketListingId);
+
+        marketListing.validateSelling();
+        wallet.checkBalanceAvailable(marketListing.getTotalPrice());
+
+        Order order = orderService.createOrder(buyer, marketListing);
+
+        walletService.payForOrder(wallet, marketListing, order);
+        pendingAssetService.createTradePendingAsset(marketListing, order, buyer);
+
+        marketListing.updateStatus(MarketListingStatus.SOLD);
+
+        return CreateOrderResponse.create(order, marketListing.getItemName());
+    }
+}

--- a/src/main/java/com/example/tradedemo/domain/order/service/OrderService.java
+++ b/src/main/java/com/example/tradedemo/domain/order/service/OrderService.java
@@ -1,33 +1,12 @@
 package com.example.tradedemo.domain.order.service;
 
-import com.example.tradedemo.common.exception.ErrorEnum;
-import com.example.tradedemo.common.exception.ServiceException;
 import com.example.tradedemo.domain.marketlistings.entity.MarketListing;
-import com.example.tradedemo.domain.marketlistings.enums.MarketListingStatus;
-import com.example.tradedemo.domain.marketlistings.repository.MarketListingRepository;
 import com.example.tradedemo.domain.members.entity.Member;
-import com.example.tradedemo.domain.members.repository.MemberRepository;
-import com.example.tradedemo.domain.order.dto.CreateOrderResponse;
 import com.example.tradedemo.domain.order.dto.GetTransactionResponse;
 import com.example.tradedemo.domain.order.entity.Order;
 import com.example.tradedemo.domain.order.repository.OrderRepository;
-
-import java.math.BigDecimal;
-import java.time.LocalDateTime;
 import java.util.List;
-
-import com.example.tradedemo.domain.pending.entity.PendingAsset;
-import com.example.tradedemo.domain.pending.enums.PendingType;
-import com.example.tradedemo.domain.pending.enums.Type;
-import com.example.tradedemo.domain.pending.repository.PendingAssetRepository;
-import com.example.tradedemo.domain.wallet.entity.Wallet;
-import com.example.tradedemo.domain.wallet.entity.WalletHistories;
-import com.example.tradedemo.domain.wallet.enums.WalletStatus;
-import com.example.tradedemo.domain.wallet.repository.WalletHistoryRepository;
-import com.example.tradedemo.domain.wallet.repository.WalletRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.cache.annotation.CacheEvict;
-import org.springframework.cache.annotation.Caching;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -36,220 +15,6 @@ import org.springframework.transaction.annotation.Transactional;
 public class OrderService {
 
     private final OrderRepository orderRepository;
-    private final MarketListingRepository marketListingRepository;
-    private final MemberRepository memberRepository;
-    private final WalletRepository walletRepository;
-    private final PendingAssetRepository pendingAssetRepository;
-    private final WalletHistoryRepository walletHistoryRepository;
-
-    /**
-     * 상품 구매
-     */
-    public void purchase(Long buyerId, Long marketListingId) {
-
-        /**
-         * 구매자
-         */
-        Member buyer = memberRepository.findById(buyerId).orElseThrow();
-
-        /**
-         * 지갑 조회
-         * 돈 있는지 확인하고 구매해야 한다.
-         */
-        Wallet wallet = walletRepository.findByMemberId(buyerId).orElseThrow();
-        /**
-         * 거래 매물
-         */
-        MarketListing marketlisting =
-                marketListingRepository.findById(marketListingId).orElseThrow();
-        /**
-         * 이미 판매된 상품 또는 구매 불가 상태
-         */
-        if (marketlisting.getStatus() != MarketListingStatus.SELLING) {
-            throw new IllegalStateException("이미 판매되었거나 구매할 수 없는 상품입니다.");
-        }
-        /**
-         * 가격
-         */
-        BigDecimal price = marketlisting.getTotalPrice();
-        /**
-         * 잔액 비교
-         * 구매자의 돈과 총 가격 비교
-         */
-        if (wallet.getBalance().compareTo(price) < 0) {
-            throw new ServiceException(ErrorEnum.ERR_WALLET_INSUFFICIENT_BALANCE_BAD_REQUEST);
-        }
-        /**
-         * 판매자
-         */
-        Member seller = marketlisting.getMember();
-
-        /**
-         * 주문 ID 생성
-         */
-        Order order = Order.create(
-                marketlisting.getTotalPrice(),
-                marketlisting.getQuantity(),
-                seller,
-                buyer,
-                marketlisting,
-                marketlisting.getMemberItem().getItem() // 거래 매물의 인벤토리의 아이템도감 id
-                );
-
-        orderRepository.save(order);
-        /**
-         * 지갑에서 돈 차감
-         */
-        wallet.decrease(price);
-        /**
-         * 구매자 WalletHistory  : 기록
-         * price.negate()       : - 가격
-         * wallet.getBalance()  : 차감 후 잔액
-         */
-        walletHistoryRepository.save(WalletHistories.create(
-                        price.negate(),
-                        WalletStatus.PURCHASE,
-                        wallet.getBalance(),
-                        wallet,
-                        null,
-                        wallet.getMember(),
-                        order
-                )
-        );
-        /**
-         * 판매자 돈 수령 대기
-         */
-        PendingAsset sellerPending = PendingAsset.create(
-                PendingType.SALE_SUCCESS,
-                Type.MONEY,
-                marketlisting.getTotalPrice(),
-                0L,
-                false,
-                null,
-                LocalDateTime.now().plusDays(1),
-                marketlisting,
-                order,
-                seller
-        );
-
-        /**
-         * 구매자 아이템 수령 대기
-         */
-        PendingAsset buyerPending = PendingAsset.create(
-                PendingType.PURCHASE_SUCCESS,
-                Type.ITEM,
-                BigDecimal.ZERO,
-                marketlisting.getQuantity(),
-                false,
-                null,
-                LocalDateTime.now().plusDays(1),
-                marketlisting,
-                order,
-                buyer
-        );
-
-        /**
-         * 구매자 수령 대기 상태
-         */
-        pendingAssetRepository.save(sellerPending);
-        /**
-         * 판매자 수령 대기 상태
-         */
-        pendingAssetRepository.save(buyerPending);
-
-        /**
-         * 매물 상태 변경 : SELLING → SOLD
-         */
-        marketlisting.updateStatus(MarketListingStatus.SOLD);
-    }
-
-    @Transactional
-    @Caching(evict = {
-        @CacheEvict(cacheNames = "marketListingsFirstPage", allEntries = true),
-        @CacheEvict(cacheNames = "marketListingItem", key = "'listing:' + #marketListingId")
-    })
-    public CreateOrderResponse purchaseV2(Long buyerId, Long marketListingId) {
-        Member buyer = memberRepository.findById(buyerId).orElseThrow(
-                () -> new ServiceException(ErrorEnum.ERR_MEMBER_NOT_FOUND)
-        );
-        Wallet wallet = walletRepository.findByMemberId(buyerId).orElseThrow(
-                () -> new ServiceException(ErrorEnum.ERR_WALLET_NOT_FOUND)
-        );
-
-        MarketListing marketlisting = marketListingRepository.findById(marketListingId).orElseThrow(
-                () -> new ServiceException(ErrorEnum.ERR_MARKET_LISTING_NOT_FOUND)
-        );
-
-        if (marketlisting.getStatus() != MarketListingStatus.SELLING) {
-            throw new ServiceException(ErrorEnum.ERR_MARKET_LISTING_NOT_SELLING);
-        }
-
-        BigDecimal price = marketlisting.getTotalPrice();
-
-        if (wallet.getBalance().compareTo(price) < 0) {
-            throw new ServiceException(ErrorEnum.ERR_WALLET_INSUFFICIENT_BALANCE_BAD_REQUEST);
-        }
-
-        Member seller = marketlisting.getMember();
-
-        Order order = Order.create(
-                marketlisting.getTotalPrice(),
-                marketlisting.getQuantity(),
-                seller,
-                buyer,
-                marketlisting,
-                marketlisting.getMemberItem().getItem() // 거래 매물의 인벤토리의 아이템도감 id
-        );
-
-        orderRepository.save(order);
-
-        wallet.decrease(price);
-
-        walletHistoryRepository.save(WalletHistories.create(
-                        price.negate(),
-                        WalletStatus.PURCHASE,
-                        wallet.getBalance(),
-                        wallet,
-                        null,
-                        wallet.getMember(),
-                        order
-                )
-        );
-
-        PendingAsset sellerPending = PendingAsset.create(
-                PendingType.SALE_SUCCESS,
-                Type.MONEY,
-                marketlisting.getTotalPrice(),
-                0L,
-                false,
-                null,
-                LocalDateTime.now().plusDays(1),
-                marketlisting,
-                order,
-                seller
-        );
-
-        PendingAsset buyerPending = PendingAsset.create(
-                PendingType.PURCHASE_SUCCESS,
-                Type.ITEM,
-                BigDecimal.ZERO,
-                marketlisting.getQuantity(),
-                false,
-                null,
-                LocalDateTime.now().plusDays(1),
-                marketlisting,
-                order,
-                buyer
-        );
-
-        pendingAssetRepository.save(sellerPending);
-        pendingAssetRepository.save(buyerPending);
-
-        marketlisting.updateStatus(MarketListingStatus.SOLD);
-
-        return CreateOrderResponse.create(order, marketlisting.getItemName());
-    }
-
 
     /**
      * 내 구매 내역 조회
@@ -271,5 +36,24 @@ public class OrderService {
         return orderRepository.findBySellerId(memberId).stream()
                 .map(GetTransactionResponse::of)
                 .toList();
+    }
+
+    /**
+     * 주문 생성
+     */
+    @Transactional
+    public Order createOrder(Member buyer, MarketListing marketListing) {
+        Order order = Order.create(
+                marketListing.getTotalPrice(),
+                marketListing.getQuantity(),
+                marketListing.getMember(),  // 구매자
+                buyer,
+                marketListing,
+                marketListing.getMemberItem().getItem() // 거래 매물의 인벤토리의 아이템도감 id
+                );
+
+        orderRepository.save(order);
+
+        return order;
     }
 }

--- a/src/main/java/com/example/tradedemo/domain/pending/service/PendingAssetService.java
+++ b/src/main/java/com/example/tradedemo/domain/pending/service/PendingAssetService.java
@@ -4,10 +4,12 @@ import com.example.tradedemo.common.exception.ErrorEnum;
 import com.example.tradedemo.common.exception.ServiceException;
 import com.example.tradedemo.domain.item.entity.Item;
 import com.example.tradedemo.domain.item.repository.ItemRepository;
+import com.example.tradedemo.domain.marketlistings.entity.MarketListing;
 import com.example.tradedemo.domain.members.entity.Member;
 import com.example.tradedemo.domain.members.entity.MemberItem;
 import com.example.tradedemo.domain.members.repository.MemberItemRepository;
 import com.example.tradedemo.domain.members.repository.MemberRepository;
+import com.example.tradedemo.domain.order.entity.Order;
 import com.example.tradedemo.domain.pending.dto.PendingAssetResponse;
 import com.example.tradedemo.domain.pending.entity.PendingAsset;
 import com.example.tradedemo.domain.pending.enums.PendingType;
@@ -26,6 +28,7 @@ import org.springframework.cache.annotation.Caching;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -208,5 +211,37 @@ public class PendingAssetService {
 
         asset.setClaimed(true);
         asset.setClaimedAt(LocalDateTime.now());
+    }
+
+    @Transactional
+    public void createTradePendingAsset(MarketListing marketListing, Order order, Member buyer) {
+        PendingAsset sellerPending = PendingAsset.create(
+                PendingType.SALE_SUCCESS,
+                Type.MONEY,
+                marketListing.getTotalPrice(),
+                0L,
+                false,
+                null,
+                LocalDateTime.now().plusDays(1),
+                marketListing,
+                order,
+                marketListing.getMember()
+        );
+
+        PendingAsset buyerPending = PendingAsset.create(
+                PendingType.PURCHASE_SUCCESS,
+                Type.ITEM,
+                BigDecimal.ZERO,
+                marketListing.getQuantity(),
+                false,
+                null,
+                LocalDateTime.now().plusDays(1),
+                marketListing,
+                order,
+                buyer
+        );
+
+        pendingAssetRepository.save(sellerPending);
+        pendingAssetRepository.save(buyerPending);
     }
 }

--- a/src/main/java/com/example/tradedemo/domain/wallet/entity/Wallet.java
+++ b/src/main/java/com/example/tradedemo/domain/wallet/entity/Wallet.java
@@ -1,6 +1,8 @@
 package com.example.tradedemo.domain.wallet.entity;
 
 import com.example.tradedemo.common.entity.Base;
+import com.example.tradedemo.common.exception.ErrorEnum;
+import com.example.tradedemo.common.exception.ServiceException;
 import com.example.tradedemo.domain.members.entity.Member;
 import jakarta.persistence.*;
 import java.math.BigDecimal;
@@ -58,5 +60,11 @@ public class Wallet extends Base {
             throw new IllegalArgumentException("잔액 부족");
         }
         this.balance = this.balance.subtract(amount);
+    }
+
+    public void checkBalanceAvailable(BigDecimal amount) {
+        if (this.getBalance().compareTo(amount) < 0) {
+            throw new ServiceException(ErrorEnum.ERR_WALLET_INSUFFICIENT_BALANCE_BAD_REQUEST);
+        }
     }
 }

--- a/src/main/java/com/example/tradedemo/domain/wallet/service/WalletService.java
+++ b/src/main/java/com/example/tradedemo/domain/wallet/service/WalletService.java
@@ -1,7 +1,14 @@
 package com.example.tradedemo.domain.wallet.service;
 
+import com.example.tradedemo.common.exception.ErrorEnum;
+import com.example.tradedemo.common.exception.ServiceException;
+import com.example.tradedemo.domain.marketlistings.entity.MarketListing;
+import com.example.tradedemo.domain.order.entity.Order;
 import com.example.tradedemo.domain.wallet.dto.WalletResponse;
 import com.example.tradedemo.domain.wallet.entity.Wallet;
+import com.example.tradedemo.domain.wallet.entity.WalletHistories;
+import com.example.tradedemo.domain.wallet.enums.WalletStatus;
+import com.example.tradedemo.domain.wallet.repository.WalletHistoryRepository;
 import com.example.tradedemo.domain.wallet.repository.WalletRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -12,6 +19,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class WalletService {
 
     private final WalletRepository walletRepository;
+    private final WalletHistoryRepository walletHistoryRepository;
 
     /**
      * 내 지갑 조회
@@ -22,5 +30,28 @@ public class WalletService {
         Wallet wallet = walletRepository.findByMemberId(memberId).orElseThrow();
 
         return WalletResponse.of(wallet);
+    }
+
+    @Transactional(readOnly = true)
+    public Wallet findWallet(Long buyerId) {
+        return walletRepository.findByMemberId(buyerId).orElseThrow(
+                () -> new ServiceException(ErrorEnum.ERR_WALLET_NOT_FOUND)
+        );
+    }
+
+    @Transactional
+    public void payForOrder(Wallet wallet, MarketListing marketListing, Order order) {
+        wallet.decrease(marketListing.getTotalPrice());
+
+        walletHistoryRepository.save(WalletHistories.create(
+                marketListing.getTotalPrice().negate(),
+                        WalletStatus.PURCHASE,
+                        wallet.getBalance(),
+                        wallet,
+                        null,
+                        wallet.getMember(),
+                        order
+                )
+        );
     }
 }


### PR DESCRIPTION
# Work History
작업 내역 적기
- order controller과 order service 사이에 order facade 레이어 추가
- 상품 구매 메서드를 구성하는 로직을 각 도메인의 서비스 레이어의 로직으로 분리

# Releated Issue
Refs #80 

# CheckList
- [ ] Commit Convention 준수 여부 확인
- [ ] 코드에 대해서 주석 작성 여부 확인
- [ ] 불필요 주석, import, Test Log 삭제 여부 확인

# ETC
코드에 대한 설명이나 후처리에 관해 기록할 사항을 적을 것