### PR TITLE
feat: coupon 도메인 V3 Redis Cache 적용

### DIFF
--- a/src/main/java/com/example/tradedemo/domain/coupon/constants/CouponCacheConst.java
+++ b/src/main/java/com/example/tradedemo/domain/coupon/constants/CouponCacheConst.java
@@ -1,0 +1,25 @@
+package com.example.tradedemo.domain.coupon.constants;
+
+public final class CouponCacheConst {
+
+    // 쿠폰 정책 목록
+    public static final long COUPON_POLICIES_TTL_MINUTES  = 10;
+
+    // 내 쿠폰 목록/단건
+    public static final long MEMBER_COUPONS_TTL_MINUTES   = 5;
+
+    // 쿠폰 사용 내역: 사용 시
+    public static final long COUPON_HISTORIES_TTL_MINUTES = 10;
+
+
+    // 쿠폰 정책 목록 캐시 키
+    public static final String POLICIES_PREFIX  = "coupon:policies:";
+
+    // 내 쿠폰(목록/단건) 캐시 키
+    public static final String COUPONS_PREFIX   = "coupon:member:";
+
+    // 쿠폰 사용 내역 캐시 키
+    public static final String HISTORIES_PREFIX = "coupon:histories:member:";
+
+    private CouponCacheConst() {}
+}

--- a/src/main/java/com/example/tradedemo/domain/coupon/controller/CouponController.java
+++ b/src/main/java/com/example/tradedemo/domain/coupon/controller/CouponController.java
@@ -58,7 +58,7 @@ public class CouponController {
         Pageable pageable = PageRequest.of(page, 10);
 
         PageResponse<SearchAllCouponPolicyResponse> response =
-                PageResponse.of(couponService.searchAllCouponPolicies(sortCreatedAt, issueType, pageable));
+                couponService.searchAllCouponPolicies(sortCreatedAt, issueType, pageable);
 
         return ResponseEntity.ok(ApiResponse.success(String.valueOf(HttpStatus.OK.value()), response));
     }
@@ -72,7 +72,7 @@ public class CouponController {
         Pageable pageable = PageRequest.of(page, 10);
 
         PageResponse<SearchAllCouponPolicyResponse> response =
-                PageResponse.of(couponService.searchAllCouponPoliciesV2(sortCreatedAt, issueType, pageable));
+                couponService.searchAllCouponPoliciesV2(sortCreatedAt, issueType, pageable);
 
         return ResponseEntity.ok(ApiResponse.success(String.valueOf(HttpStatus.OK.value()), response));
     }
@@ -91,7 +91,7 @@ public class CouponController {
         Pageable pageable = PageRequest.of(page, 10);
         Long memberId = principalDetails.getMember().getId();
         PageResponse<SearchAllMemberCouponResponse> response =
-                PageResponse.of(couponService.getAllMemberCoupon(memberId, status, pageable));
+                couponService.getAllMemberCoupon(memberId, status, pageable);
 
         return ResponseEntity.ok(ApiResponse.success(String.valueOf(HttpStatus.OK.value()), response));
     }
@@ -105,7 +105,7 @@ public class CouponController {
         Pageable pageable = PageRequest.of(page, 10);
         Long memberId = principalDetails.getMember().getId();
         PageResponse<SearchAllMemberCouponResponse> response =
-                PageResponse.of(couponService.getAllMemberCouponV2(memberId, status, pageable));
+                couponService.getAllMemberCouponV2(memberId, status, pageable);
 
         return ResponseEntity.ok(ApiResponse.success(String.valueOf(HttpStatus.OK.value()), response));
     }
@@ -222,7 +222,7 @@ public class CouponController {
         Pageable pageable = PageRequest.of(page, 10);
         Long memberId = principalDetails.getMember().getId();
         PageResponse<SearchAllCouponHistoryResponse> response =
-                PageResponse.of(couponService.getAllCouponHistory(memberId, status, sortCreatedAt, pageable));
+                couponService.getAllCouponHistory(memberId, status, sortCreatedAt, pageable);
 
         return ResponseEntity.ok(ApiResponse.success(String.valueOf(HttpStatus.OK.value()), response));
     }
@@ -237,7 +237,7 @@ public class CouponController {
         Pageable pageable = PageRequest.of(page, 10);
         Long memberId = principalDetails.getMember().getId();
         PageResponse<SearchAllCouponHistoryResponse> response =
-                PageResponse.of(couponService.getAllCouponHistoryV2(memberId, status, sortCreatedAt, pageable));
+                couponService.getAllCouponHistoryV2(memberId, status, sortCreatedAt, pageable);
 
         return ResponseEntity.ok(ApiResponse.success(String.valueOf(HttpStatus.OK.value()), response));
     }

--- a/src/main/java/com/example/tradedemo/domain/coupon/controller/CouponController.java
+++ b/src/main/java/com/example/tradedemo/domain/coupon/controller/CouponController.java
@@ -42,6 +42,14 @@ public class CouponController {
                 .body(ApiResponse.success(String.valueOf(HttpStatus.OK.value()), response));
     }
 
+    @PostMapping("/api/v3/admin/coupon-policies")
+    public ResponseEntity<ApiResponse<CreateCouponPolicyResponse>> createCouponPolicyV3(
+            @Valid @RequestBody CreateCouponPolicyRequest request) {
+        CreateCouponPolicyResponse response = couponService.createCouponPolicyV3(request);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.success(String.valueOf(HttpStatus.OK.value()), response));
+    }
+
 
     /**
      * 쿠폰 정책 조회
@@ -49,7 +57,7 @@ public class CouponController {
      * issueType 값을 FIRST_COME/AUTO_SIGNUP 으로 전달하여 정렬 조건 추가 가능
      * issueType FIRST_COME/AUTO_SIGNUP 외 다른 값 입력 시 무시 -> 조건 추가 X
      */
-    @GetMapping("/api/v1/coupon-policies")
+    @GetMapping("/api/v1/couponPolicies")
     public ResponseEntity<ApiResponse<PageResponse<SearchAllCouponPolicyResponse>>> searchAllCouponPolicies(
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(required = false) String sortCreatedAt,
@@ -63,7 +71,7 @@ public class CouponController {
         return ResponseEntity.ok(ApiResponse.success(String.valueOf(HttpStatus.OK.value()), response));
     }
 
-    @GetMapping("/api/v2/coupon-policies")
+    @GetMapping("/api/v2/couponPolicies")
     public ResponseEntity<ApiResponse<PageResponse<SearchAllCouponPolicyResponse>>> searchAllCouponPoliciesV2(
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(required = false) String sortCreatedAt,
@@ -73,6 +81,20 @@ public class CouponController {
 
         PageResponse<SearchAllCouponPolicyResponse> response =
                 couponService.searchAllCouponPoliciesV2(sortCreatedAt, issueType, pageable);
+
+        return ResponseEntity.ok(ApiResponse.success(String.valueOf(HttpStatus.OK.value()), response));
+    }
+
+    @GetMapping("/api/v3/couponPolicies")
+    public ResponseEntity<ApiResponse<PageResponse<SearchAllCouponPolicyResponse>>> searchAllCouponPoliciesV3(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(required = false) String sortCreatedAt,
+            @RequestParam(required = false) String issueType) {
+
+        Pageable pageable = PageRequest.of(page, 10);
+
+        PageResponse<SearchAllCouponPolicyResponse> response =
+                couponService.searchAllCouponPoliciesV3(sortCreatedAt, issueType, pageable);
 
         return ResponseEntity.ok(ApiResponse.success(String.valueOf(HttpStatus.OK.value()), response));
     }
@@ -110,6 +132,20 @@ public class CouponController {
         return ResponseEntity.ok(ApiResponse.success(String.valueOf(HttpStatus.OK.value()), response));
     }
 
+    @GetMapping("/api/v3/me/coupons")
+    public ResponseEntity<ApiResponse<PageResponse<SearchAllMemberCouponResponse>>> getAllMemberCouponV3(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(required = false) String status,
+            @AuthenticationPrincipal PrincipalDetails principalDetails) {
+
+        Pageable pageable = PageRequest.of(page, 10);
+        Long memberId = principalDetails.getMember().getId();
+        PageResponse<SearchAllMemberCouponResponse> response =
+                couponService.getAllMemberCouponV3(memberId, status, pageable);
+
+        return ResponseEntity.ok(ApiResponse.success(String.valueOf(HttpStatus.OK.value()), response));
+    }
+
     /**
      * 내 쿠폰 단건 조회
      */
@@ -131,6 +167,16 @@ public class CouponController {
         Long memberId = principalDetails.getMember().getId();
 
         SearchAllMemberCouponResponse response = couponService.getMemberCouponV2(memberId, couponId);
+
+        return ResponseEntity.ok(ApiResponse.success(String.valueOf(HttpStatus.OK.value()), response));
+    }
+
+    @GetMapping("/api/v3/me/coupons/{couponId}")
+    public ResponseEntity<ApiResponse<SearchAllMemberCouponResponse>> getMemberCouponV3(
+            @PathVariable Long couponId, @AuthenticationPrincipal PrincipalDetails principalDetails) {
+
+        Long memberId = principalDetails.getMember().getId();
+        SearchAllMemberCouponResponse response = couponService.getMemberCouponV3(memberId, couponId);
 
         return ResponseEntity.ok(ApiResponse.success(String.valueOf(HttpStatus.OK.value()), response));
     }
@@ -207,6 +253,17 @@ public class CouponController {
         return ResponseEntity.ok(ApiResponse.success(String.valueOf(HttpStatus.OK.value()), CouponMessage.COUPON_USED));
     }
 
+    @PostMapping("/api/v3/me/coupons/{memberCouponId}/use")
+    public ResponseEntity<ApiResponse<String>> useCouponV3(
+            @PathVariable Long memberCouponId, @AuthenticationPrincipal PrincipalDetails principalDetails) {
+
+        Long memberId = principalDetails.getMember().getId();
+        Member member = principalDetails.getMember();
+        couponFacade.useCouponV3(memberId, memberCouponId, member);
+
+        return ResponseEntity.ok(ApiResponse.success(String.valueOf(HttpStatus.OK.value()), CouponMessage.COUPON_USED));
+    }
+
     /**
      * 내 쿠폰 사용 내역 조회
      * status 값을 USED/EXPIRED 로 전달하여 필터 조건 추가 가능
@@ -238,6 +295,21 @@ public class CouponController {
         Long memberId = principalDetails.getMember().getId();
         PageResponse<SearchAllCouponHistoryResponse> response =
                 couponService.getAllCouponHistoryV2(memberId, status, sortCreatedAt, pageable);
+
+        return ResponseEntity.ok(ApiResponse.success(String.valueOf(HttpStatus.OK.value()), response));
+    }
+
+    @GetMapping("/api/v3/me/coupons-histories")
+    public ResponseEntity<ApiResponse<PageResponse<SearchAllCouponHistoryResponse>>> getAllCouponHistoryV3(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(required = false) String status,
+            @RequestParam(required = false) String sortCreatedAt,
+            @AuthenticationPrincipal PrincipalDetails principalDetails) {
+
+        Pageable pageable = PageRequest.of(page, 10);
+        Long memberId = principalDetails.getMember().getId();
+        PageResponse<SearchAllCouponHistoryResponse> response =
+                couponService.getAllCouponHistoryV3(memberId, status, sortCreatedAt, pageable);
 
         return ResponseEntity.ok(ApiResponse.success(String.valueOf(HttpStatus.OK.value()), response));
     }

--- a/src/main/java/com/example/tradedemo/domain/coupon/facade/CouponFacade.java
+++ b/src/main/java/com/example/tradedemo/domain/coupon/facade/CouponFacade.java
@@ -2,6 +2,7 @@ package com.example.tradedemo.domain.coupon.facade;
 
 import com.example.tradedemo.domain.coupon.entity.CouponHistory;
 import com.example.tradedemo.domain.coupon.exception.CouponExpiredException;
+import com.example.tradedemo.domain.coupon.service.CouponCacheService;
 import com.example.tradedemo.domain.coupon.service.CouponService;
 import com.example.tradedemo.domain.members.entity.Member;
 import com.example.tradedemo.domain.wallet.entity.Wallet;
@@ -18,6 +19,7 @@ public class CouponFacade {
 
     private final CouponService couponService;
     private final WalletService walletService;
+    private final CouponCacheService couponCacheService;
 
     @Transactional(noRollbackFor = CouponExpiredException.class)
     public void useCoupon(Long memberId, Long memberCouponId, Member member) {
@@ -48,5 +50,18 @@ public class CouponFacade {
 
         // 지갑 잔액 추가 + 지갑 히스토리 저장
         walletService.addCouponBalance(wallet, couponHistory, member);
+    }
+
+    @Transactional(noRollbackFor = CouponExpiredException.class)
+    public void useCouponV3(Long memberId, Long memberCouponId, Member member) {
+        CouponHistory couponHistory = couponService.useCoupon(memberId, memberCouponId, member);
+
+        Wallet wallet = walletService.findWallet(memberId);
+        walletService.addCouponBalance(wallet, couponHistory, member);
+
+        // Redis 캐시 무효화
+        couponCacheService.evictAllMemberCoupons(memberId);
+        couponCacheService.evictMemberCouponItem(memberId, memberCouponId);
+        couponCacheService.evictAllCouponHistories(memberId);
     }
 }

--- a/src/main/java/com/example/tradedemo/domain/coupon/repository/CouponHistoryCustomRepository.java
+++ b/src/main/java/com/example/tradedemo/domain/coupon/repository/CouponHistoryCustomRepository.java
@@ -1,10 +1,11 @@
 package com.example.tradedemo.domain.coupon.repository;
 
+import com.example.tradedemo.common.dto.PageResponse;
 import com.example.tradedemo.domain.coupon.dto.SearchAllCouponHistoryResponse;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface CouponHistoryCustomRepository {
-    Page<SearchAllCouponHistoryResponse> findAllCouponHistoryByMemberId(
+    PageResponse<SearchAllCouponHistoryResponse> findAllCouponHistoryByMemberId(
             Long memberId, String status, String sortCreatedAt, Pageable pageable);
 }

--- a/src/main/java/com/example/tradedemo/domain/coupon/repository/CouponHistoryCustomRepositoryImpl.java
+++ b/src/main/java/com/example/tradedemo/domain/coupon/repository/CouponHistoryCustomRepositoryImpl.java
@@ -4,6 +4,7 @@ import static com.example.tradedemo.domain.coupon.entity.QCouponHistory.couponHi
 import static com.example.tradedemo.domain.coupon.entity.QCouponPolicy.couponPolicy;
 import static com.example.tradedemo.domain.coupon.entity.QMemberCoupon.memberCoupon;
 
+import com.example.tradedemo.common.dto.PageResponse;
 import com.example.tradedemo.domain.coupon.dto.SearchAllCouponHistoryResponse;
 import com.example.tradedemo.domain.coupon.entity.CouponHistory;
 import com.example.tradedemo.domain.coupon.enums.CouponHistoryStatus;
@@ -12,7 +13,6 @@ import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 
@@ -22,7 +22,7 @@ public class CouponHistoryCustomRepositoryImpl implements CouponHistoryCustomRep
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public Page<SearchAllCouponHistoryResponse> findAllCouponHistoryByMemberId(
+    public PageResponse<SearchAllCouponHistoryResponse> findAllCouponHistoryByMemberId(
             Long memberId, String status, String sortCreatedAt, Pageable pageable) {
 
         BooleanBuilder builder = new BooleanBuilder();
@@ -57,7 +57,7 @@ public class CouponHistoryCustomRepositoryImpl implements CouponHistoryCustomRep
                 .where(builder)
                 .fetchOne();
 
-        return new PageImpl<>(
-                content.stream().map(SearchAllCouponHistoryResponse::of).toList(), pageable, total == null ? 0 : total);
+        return PageResponse.of(new PageImpl<>(
+                content.stream().map(SearchAllCouponHistoryResponse::of).toList(), pageable, total == null ? 0 : total));
     }
 }

--- a/src/main/java/com/example/tradedemo/domain/coupon/repository/CouponPolicyCustomRepository.java
+++ b/src/main/java/com/example/tradedemo/domain/coupon/repository/CouponPolicyCustomRepository.java
@@ -1,9 +1,9 @@
 package com.example.tradedemo.domain.coupon.repository;
 
+import com.example.tradedemo.common.dto.PageResponse;
 import com.example.tradedemo.domain.coupon.dto.SearchAllCouponPolicyResponse;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface CouponPolicyCustomRepository {
-    Page<SearchAllCouponPolicyResponse> getAllCouponPolicy(String sortCreatedAt, String issueType, Pageable pageable);
+    PageResponse<SearchAllCouponPolicyResponse> getAllCouponPolicy(String sortCreatedAt, String issueType, Pageable pageable);
 }

--- a/src/main/java/com/example/tradedemo/domain/coupon/repository/CouponPolicyCustomRepositoryImpl.java
+++ b/src/main/java/com/example/tradedemo/domain/coupon/repository/CouponPolicyCustomRepositoryImpl.java
@@ -2,6 +2,7 @@ package com.example.tradedemo.domain.coupon.repository;
 
 import static com.example.tradedemo.domain.coupon.entity.QCouponPolicy.couponPolicy;
 
+import com.example.tradedemo.common.dto.PageResponse;
 import com.example.tradedemo.domain.coupon.dto.SearchAllCouponPolicyResponse;
 import com.example.tradedemo.domain.coupon.entity.CouponPolicy;
 import com.example.tradedemo.domain.coupon.enums.IssueType;
@@ -10,7 +11,6 @@ import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 
@@ -20,7 +20,7 @@ public class CouponPolicyCustomRepositoryImpl implements CouponPolicyCustomRepos
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public Page<SearchAllCouponPolicyResponse> getAllCouponPolicy(
+    public PageResponse<SearchAllCouponPolicyResponse> getAllCouponPolicy(
             String sortCreatedAt, String issueType, Pageable pageable) {
 
         // issueType 필터
@@ -50,7 +50,7 @@ public class CouponPolicyCustomRepositoryImpl implements CouponPolicyCustomRepos
                 .where(builder)
                 .fetchOne();
 
-        return new PageImpl<>(
-                content.stream().map(SearchAllCouponPolicyResponse::of).toList(), pageable, total == null ? 0 : total);
+        return PageResponse.of(new PageImpl<>(
+                content.stream().map(SearchAllCouponPolicyResponse::of).toList(), pageable, total == null ? 0 : total));
     }
 }

--- a/src/main/java/com/example/tradedemo/domain/coupon/repository/MemberCouponCustomRepository.java
+++ b/src/main/java/com/example/tradedemo/domain/coupon/repository/MemberCouponCustomRepository.java
@@ -1,16 +1,16 @@
 package com.example.tradedemo.domain.coupon.repository;
 
+import com.example.tradedemo.common.dto.PageResponse;
 import com.example.tradedemo.domain.coupon.dto.SearchAllMemberCouponResponse;
 import com.example.tradedemo.domain.coupon.entity.MemberCoupon;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface MemberCouponCustomRepository {
 
-    Page<SearchAllMemberCouponResponse> findAllMemberCouponByMemberId(Long memberId, String status, Pageable pageable);
+    PageResponse<SearchAllMemberCouponResponse> findAllMemberCouponByMemberId(Long memberId, String status, Pageable pageable);
 
     Optional<SearchAllMemberCouponResponse> findMemberCouponByMemberIdAndMemberCouponId(Long memberId, Long couponId);
 

--- a/src/main/java/com/example/tradedemo/domain/coupon/repository/MemberCouponCustomRepositoryImpl.java
+++ b/src/main/java/com/example/tradedemo/domain/coupon/repository/MemberCouponCustomRepositoryImpl.java
@@ -3,6 +3,7 @@ package com.example.tradedemo.domain.coupon.repository;
 import static com.example.tradedemo.domain.coupon.entity.QCouponPolicy.couponPolicy;
 import static com.example.tradedemo.domain.coupon.entity.QMemberCoupon.memberCoupon;
 
+import com.example.tradedemo.common.dto.PageResponse;
 import com.example.tradedemo.domain.coupon.dto.SearchAllMemberCouponResponse;
 import com.example.tradedemo.domain.coupon.entity.MemberCoupon;
 import com.example.tradedemo.domain.coupon.enums.CouponStatus;
@@ -14,7 +15,6 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 
@@ -24,7 +24,7 @@ public class MemberCouponCustomRepositoryImpl implements MemberCouponCustomRepos
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public Page<SearchAllMemberCouponResponse> findAllMemberCouponByMemberId(
+    public PageResponse<SearchAllMemberCouponResponse> findAllMemberCouponByMemberId(
             Long memberId, String status, Pageable pageable) {
 
         BooleanBuilder builder = new BooleanBuilder();
@@ -64,8 +64,8 @@ public class MemberCouponCustomRepositoryImpl implements MemberCouponCustomRepos
                 .where(builder)
                 .fetchOne();
 
-        return new PageImpl<>(
-                content.stream().map(SearchAllMemberCouponResponse::of).toList(), pageable, total == null ? 0 : total);
+        return PageResponse.of(new PageImpl<>(
+                content.stream().map(SearchAllMemberCouponResponse::of).toList(), pageable, total == null ? 0 : total));
     }
 
     @Override

--- a/src/main/java/com/example/tradedemo/domain/coupon/service/CouponCacheService.java
+++ b/src/main/java/com/example/tradedemo/domain/coupon/service/CouponCacheService.java
@@ -1,0 +1,137 @@
+package com.example.tradedemo.domain.coupon.service;
+
+import com.example.tradedemo.common.dto.PageResponse;
+import com.example.tradedemo.domain.coupon.constants.CouponCacheConst;
+import com.example.tradedemo.domain.coupon.dto.SearchAllCouponHistoryResponse;
+import com.example.tradedemo.domain.coupon.dto.SearchAllCouponPolicyResponse;
+import com.example.tradedemo.domain.coupon.dto.SearchAllMemberCouponResponse;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CouponCacheService {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+    private final ObjectMapper objectMapper;
+
+    // 쿠폰 정책 목록 캐시
+    public String couponPoliciesKey(int page, String sortCreatedAt, String issueType) {
+        return CouponCacheConst.POLICIES_PREFIX + "page:" + page + ":sort:" + sortCreatedAt + ":type:" + issueType;
+    }
+
+    public PageResponse<SearchAllCouponPolicyResponse> getCouponPolicies(String key) {
+        Object value = redisTemplate.opsForValue().get(key);
+        if (value == null) return null;
+        return objectMapper.convertValue(
+                value,
+                new TypeReference<PageResponse<SearchAllCouponPolicyResponse>>() {});
+    }
+
+    public void setCouponPolicies(String key, Object value) {
+        redisTemplate.opsForValue().set(
+                key, value, CouponCacheConst.COUPON_POLICIES_TTL_MINUTES, TimeUnit.MINUTES);
+        log.info("[CouponCache] 쿠폰 정책 목록 캐시 저장 - key: {}", key);
+    }
+
+    // 정책 생성 시 "coupon:policies:*" 패턴의 모든 키 삭제
+    public void evictAllCouponPolicies() {
+        var keys = redisTemplate.keys(CouponCacheConst.POLICIES_PREFIX + "*");
+        if (keys != null && !keys.isEmpty()) {
+            redisTemplate.delete(keys);
+            log.debug("[CouponCache] 쿠폰 정책 목록 캐시 전체 삭제 - {}건", keys.size());
+        }
+    }
+
+
+    // 내 쿠폰 전체 목록 캐시
+    public String memberCouponsListKey(Long memberId, int page, String status) {
+        return CouponCacheConst.COUPONS_PREFIX + memberId + ":coupons:page:" + page + ":status:" + status;
+    }
+
+    public PageResponse<SearchAllMemberCouponResponse> getMemberCouponsList(String key) {
+        Object value = redisTemplate.opsForValue().get(key);
+        if (value == null) return null;
+        return objectMapper.convertValue(
+                value,
+                new TypeReference<PageResponse<SearchAllMemberCouponResponse>>() {});
+    }
+
+    public void setMemberCouponsList(String key, Object value) {
+        redisTemplate.opsForValue().set(
+                key, value, CouponCacheConst.MEMBER_COUPONS_TTL_MINUTES, TimeUnit.MINUTES);
+        log.debug("[CouponCache] 내 쿠폰 목록 캐시 저장 - key: {}", key);
+    }
+
+    // 내 쿠폰 단건 캐시
+    public String memberCouponItemKey(Long memberId, Long couponId) {
+        return CouponCacheConst.COUPONS_PREFIX + memberId + ":coupon:" + couponId;
+    }
+
+    public SearchAllMemberCouponResponse getMemberCouponItem(String key) {
+        Object value = redisTemplate.opsForValue().get(key);
+        if (value == null) return null;
+        return objectMapper.convertValue(
+                value,
+                new TypeReference<SearchAllMemberCouponResponse>() {});
+    }
+
+    public void setMemberCouponItem(String key, Object value) {
+        redisTemplate.opsForValue().set(
+                key, value, CouponCacheConst.MEMBER_COUPONS_TTL_MINUTES, TimeUnit.MINUTES);
+        log.debug("[CouponCache] 내 쿠폰 단건 캐시 저장 - key: {}", key);
+    }
+
+    // 쿠폰 발급/사용 시 "coupon:member:{memberId}:*" 패턴의 모든 키 삭제
+    public void evictAllMemberCoupons(Long memberId) {
+        var keys = redisTemplate.keys(CouponCacheConst.COUPONS_PREFIX + memberId + ":*");
+        if (keys != null && !keys.isEmpty()) {
+            redisTemplate.delete(keys);
+            log.debug("[CouponCache] 회원 쿠폰 캐시 전체 삭제 - memberId: {}, {}건", memberId, keys.size());
+        }
+    }
+
+    public void evictMemberCouponItem(Long memberId, Long couponId) {
+        String key = memberCouponItemKey(memberId, couponId);
+        redisTemplate.delete(key);
+        log.debug("[CouponCache] 내 쿠폰 단건 캐시 삭제 - key: {}", key);
+    }
+
+
+    // 쿠폰 사용 내역 캐시
+    public String couponHistoriesKey(Long memberId, int page, String status, String sortCreatedAt) {
+        return CouponCacheConst.HISTORIES_PREFIX + memberId + ":page:" + page + ":status:" + status + ":sort:" + sortCreatedAt;
+    }
+
+    public PageResponse<SearchAllCouponHistoryResponse> getCouponHistories(String key) {
+        Object value = redisTemplate.opsForValue().get(key);
+        if (value == null) return null;
+        return objectMapper.convertValue(
+                value,
+                new TypeReference<PageResponse<SearchAllCouponHistoryResponse>>() {});
+    }
+
+    public void setCouponHistories(String key, Object value) {
+        redisTemplate.opsForValue().set(
+                key, value, CouponCacheConst.COUPON_HISTORIES_TTL_MINUTES, TimeUnit.MINUTES);
+        log.debug("[CouponCache] 쿠폰 내역 캐시 저장 - key: {}", key);
+    }
+
+    // 사용 시 호출 → "coupon:histories:member:{memberId}:*" 패턴의 모든 키 삭제
+    public void evictAllCouponHistories(Long memberId) {
+        var keys = redisTemplate.keys(CouponCacheConst.HISTORIES_PREFIX + memberId + ":*");
+        if (keys != null && !keys.isEmpty()) {
+            redisTemplate.delete(keys);
+            log.debug("[CouponCache] 쿠폰 내역 캐시 전체 삭제 - memberId: {}, {}건", memberId, keys.size());
+        }
+    }
+
+}

--- a/src/main/java/com/example/tradedemo/domain/coupon/service/CouponService.java
+++ b/src/main/java/com/example/tradedemo/domain/coupon/service/CouponService.java
@@ -39,6 +39,7 @@ public class CouponService {
     private final CouponHistoryRepository couponHistoryRepository;
     private final LockService lockService;
     private final CouponIssueService couponIssueService;
+    private final CouponCacheService couponCacheService;
 
     @Transactional
     public CreateCouponPolicyResponse createCouponPolicy(@Valid CreateCouponPolicyRequest request) {
@@ -125,6 +126,50 @@ public class CouponService {
     }
 
     @Transactional
+    public CreateCouponPolicyResponse createCouponPolicyV3(CreateCouponPolicyRequest request) {
+        // 정책 이름 중복 검사
+        if (couponPolicyRepository.existsByName(request.getName())) {
+            throw new ServiceException(ErrorEnum.ERR_COUPON_POLICY_DUPLICATE_NAME);
+        }
+
+        // FIRST_COME 이면 totalQuantity 필수
+        if (request.getIssueType() == IssueType.FIRST_COME && request.getTotalQuantity() == null) {
+            throw new ServiceException(ErrorEnum.ERR_COUPON_POLICY_FIRST_COME_QUANTITY_REQUIRED);
+        }
+
+        // AUTO_SIGNUP 은 하나만 존재할 수 있음
+        if (request.getIssueType() == IssueType.AUTO_SIGNUP
+                && couponPolicyRepository.existsByIssueType(IssueType.AUTO_SIGNUP)) {
+            throw new ServiceException(ErrorEnum.ERR_COUPON_POLICY_AUTO_SIGNUP_ALREADY_EXISTS);
+        }
+
+        LocalDateTime policyStartedAt = LocalDateTime.now();
+
+        Duration policyDuration = CouponDuration.getPolicyDuration(request.getIssueType(), request.getPolicyDuration());
+        Duration couponDuration = CouponDuration.getCouponDuration(request.getIssueType(), request.getCouponDuration());
+
+        LocalDateTime policyExpiredAt = policyDuration != null ? policyStartedAt.plus(policyDuration) : null;
+
+        CouponPolicy couponPolicy = CouponPolicy.create(
+                request.getName(),
+                request.getMoneyAmount(),
+                request.getIssueType(),
+                request.getTotalQuantity(),
+                policyStartedAt,
+                policyExpiredAt,
+                policyDuration,
+                couponDuration);
+
+        CouponPolicy savedPolicy = couponPolicyRepository.save(couponPolicy);
+
+        CreateCouponPolicyResponse response = CreateCouponPolicyResponse.from(savedPolicy);
+
+        couponCacheService.evictAllCouponPolicies();
+
+        return response;
+    }
+
+    @Transactional
     public void autoSignupCoupon(Member member) {
 
         // AUTO_SIGNUP 정책 없으면 회원가입 시 쿠폰 미발급
@@ -170,6 +215,26 @@ public class CouponService {
         return couponPolicyRepository.getAllCouponPolicy(sortCreatedAt, issueType, pageable);
     }
 
+    @Transactional(readOnly = true)
+    public PageResponse<SearchAllCouponPolicyResponse> searchAllCouponPoliciesV3(
+            String sortCreatedAt, String issueType, Pageable pageable) {
+
+        String key = couponCacheService.couponPoliciesKey(
+                pageable.getPageNumber(), sortCreatedAt, issueType);
+
+        PageResponse<SearchAllCouponPolicyResponse> cached = couponCacheService.getCouponPolicies(key);
+        if (cached != null) {
+            return cached;
+        }
+
+        PageResponse<SearchAllCouponPolicyResponse> result =
+                couponPolicyRepository.getAllCouponPolicy(sortCreatedAt, issueType, pageable);
+
+        if (!result.getContent().isEmpty()) {
+            couponCacheService.setCouponPolicies(key, result);
+        }
+        return result;
+    }
 
     @Transactional(readOnly = true)
     public PageResponse<SearchAllMemberCouponResponse> getAllMemberCoupon(Long memberId, String status, Pageable pageable) {
@@ -183,6 +248,27 @@ public class CouponService {
             unless = "#result.content.isEmpty()")
     public PageResponse<SearchAllMemberCouponResponse> getAllMemberCouponV2(Long memberId, String status, Pageable pageable) {
         return memberCouponRepository.findAllMemberCouponByMemberId(memberId, status, pageable);
+    }
+
+    @Transactional(readOnly = true)
+    public PageResponse<SearchAllMemberCouponResponse> getAllMemberCouponV3(
+            Long memberId, String status, Pageable pageable) {
+
+        String key = couponCacheService.memberCouponsListKey(
+                memberId, pageable.getPageNumber(), status);
+
+        PageResponse<SearchAllMemberCouponResponse> cached = couponCacheService.getMemberCouponsList(key);
+        if (cached != null) {
+            return cached;
+        }
+
+        PageResponse<SearchAllMemberCouponResponse> result =
+                memberCouponRepository.findAllMemberCouponByMemberId(memberId, status, pageable);
+
+        if (!result.getContent().isEmpty()) {
+            couponCacheService.setMemberCouponsList(key, result);
+        }
+        return result;
     }
 
     @Transactional(readOnly = true)
@@ -200,6 +286,24 @@ public class CouponService {
         return memberCouponRepository
                 .findMemberCouponByMemberIdAndMemberCouponId(memberId, couponId)
                 .orElseThrow(() -> new ServiceException(ErrorEnum.ERR_MEMBER_COUPON_NOT_FOUND));
+    }
+
+    @Transactional(readOnly = true)
+    public SearchAllMemberCouponResponse getMemberCouponV3(Long memberId, Long couponId) {
+
+        String key = couponCacheService.memberCouponItemKey(memberId, couponId);
+
+        SearchAllMemberCouponResponse cached = couponCacheService.getMemberCouponItem(key);
+        if (cached != null) {
+            return cached;
+        }
+
+        SearchAllMemberCouponResponse result = memberCouponRepository
+                .findMemberCouponByMemberIdAndMemberCouponId(memberId, couponId)
+                .orElseThrow(() -> new ServiceException(ErrorEnum.ERR_MEMBER_COUPON_NOT_FOUND));
+
+        couponCacheService.setMemberCouponItem(key, result);
+        return result;
     }
 
     @Transactional
@@ -282,7 +386,7 @@ public class CouponService {
     }
 
     /**
-     * Redis Redisson + @RedissonLock AOP 적용
+     * Redis Redisson + @RedissonLock AOP 적용 + Redis Cache
      */
     @RedissonLock(key = "'lock:coupon:' + #couponPolicyId")
     @Transactional
@@ -312,6 +416,9 @@ public class CouponService {
         memberCouponRepository.save(MemberCoupon.create(member, couponPolicy, issuedAt, expiredAt));
 
         couponPolicy.increaseExpendQuantity();
+
+        couponCacheService.evictAllMemberCoupons(member.getId());
+        couponCacheService.evictAllCouponPolicies();
     }
 
     public CouponHistory useCoupon(Long memberId, Long memberCouponId, Member member) {
@@ -353,5 +460,26 @@ public class CouponService {
     public PageResponse<SearchAllCouponHistoryResponse> getAllCouponHistoryV2(
             Long memberId, String status, String sortCreatedAt, Pageable pageable) {
         return couponHistoryRepository.findAllCouponHistoryByMemberId(memberId, status, sortCreatedAt, pageable);
+    }
+
+    @Transactional(readOnly = true)
+    public PageResponse<SearchAllCouponHistoryResponse> getAllCouponHistoryV3(
+            Long memberId, String status, String sortCreatedAt, Pageable pageable) {
+
+        String key = couponCacheService.couponHistoriesKey(
+                memberId, pageable.getPageNumber(), status, sortCreatedAt);
+
+        PageResponse<SearchAllCouponHistoryResponse> cached = couponCacheService.getCouponHistories(key);
+        if (cached != null) {
+            return cached;
+        }
+
+        PageResponse<SearchAllCouponHistoryResponse> result =
+                couponHistoryRepository.findAllCouponHistoryByMemberId(memberId, status, sortCreatedAt, pageable);
+
+        if (!result.getContent().isEmpty()) {
+            couponCacheService.setCouponHistories(key, result);
+        }
+        return result;
     }
 }

--- a/src/main/java/com/example/tradedemo/domain/coupon/service/CouponService.java
+++ b/src/main/java/com/example/tradedemo/domain/coupon/service/CouponService.java
@@ -2,6 +2,7 @@ package com.example.tradedemo.domain.coupon.service;
 
 import com.example.tradedemo.common.annotation.RedisLock;
 import com.example.tradedemo.common.annotation.RedissonLock;
+import com.example.tradedemo.common.dto.PageResponse;
 import com.example.tradedemo.common.exception.ErrorEnum;
 import com.example.tradedemo.common.exception.ServiceException;
 import com.example.tradedemo.domain.coupon.constants.CouponDuration;
@@ -16,11 +17,7 @@ import com.example.tradedemo.domain.coupon.repository.CouponHistoryRepository;
 import com.example.tradedemo.domain.coupon.repository.CouponPolicyRepository;
 import com.example.tradedemo.domain.coupon.repository.MemberCouponRepository;
 import com.example.tradedemo.domain.members.entity.Member;
-import com.example.tradedemo.domain.wallet.entity.Wallet;
-import com.example.tradedemo.domain.wallet.entity.WalletHistories;
-import com.example.tradedemo.domain.wallet.enums.WalletStatus;
-import com.example.tradedemo.domain.wallet.repository.WalletHistoryRepository;
-import com.example.tradedemo.domain.wallet.repository.WalletRepository;
+
 import jakarta.validation.Valid;
 import java.time.Duration;
 import java.time.LocalDateTime;
@@ -29,7 +26,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.cache.annotation.Caching;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -159,7 +155,7 @@ public class CouponService {
     }
 
     @Transactional(readOnly = true)
-    public Page<SearchAllCouponPolicyResponse> searchAllCouponPolicies(
+    public PageResponse<SearchAllCouponPolicyResponse> searchAllCouponPolicies(
             String sortCreatedAt, String issueType, Pageable pageable) {
         return couponPolicyRepository.getAllCouponPolicy(sortCreatedAt, issueType, pageable);
     }
@@ -168,15 +164,15 @@ public class CouponService {
     @Cacheable(
             value = "couponPolicies",
             key = "'page:' + #pageable.pageNumber + ':sort:' + #sortCreatedAt + ':type:' + #issueType",
-            unless = "#result.isEmpty()")
-    public Page<SearchAllCouponPolicyResponse> searchAllCouponPoliciesV2(
+            unless = "#result.content.isEmpty()")
+    public PageResponse<SearchAllCouponPolicyResponse> searchAllCouponPoliciesV2(
             String sortCreatedAt, String issueType, Pageable pageable) {
         return couponPolicyRepository.getAllCouponPolicy(sortCreatedAt, issueType, pageable);
     }
 
 
     @Transactional(readOnly = true)
-    public Page<SearchAllMemberCouponResponse> getAllMemberCoupon(Long memberId, String status, Pageable pageable) {
+    public PageResponse<SearchAllMemberCouponResponse> getAllMemberCoupon(Long memberId, String status, Pageable pageable) {
         return memberCouponRepository.findAllMemberCouponByMemberId(memberId, status, pageable);
     }
 
@@ -184,8 +180,8 @@ public class CouponService {
     @Cacheable(
             value = "memberCoupons",
             key = "'member:' + #memberId + ':page:' + #pageable.pageNumber + ':status:' + #status",
-            unless = "#result.isEmpty()")
-    public Page<SearchAllMemberCouponResponse> getAllMemberCouponV2(Long memberId, String status, Pageable pageable) {
+            unless = "#result.content.isEmpty()")
+    public PageResponse<SearchAllMemberCouponResponse> getAllMemberCouponV2(Long memberId, String status, Pageable pageable) {
         return memberCouponRepository.findAllMemberCouponByMemberId(memberId, status, pageable);
     }
 
@@ -344,7 +340,7 @@ public class CouponService {
     }
 
     @Transactional(readOnly = true)
-    public Page<SearchAllCouponHistoryResponse> getAllCouponHistory(
+    public PageResponse<SearchAllCouponHistoryResponse> getAllCouponHistory(
             Long memberId, String status, String sortCreatedAt, Pageable pageable) {
         return couponHistoryRepository.findAllCouponHistoryByMemberId(memberId, status, sortCreatedAt, pageable);
     }
@@ -353,8 +349,8 @@ public class CouponService {
     @Cacheable(
             value = "couponHistories",
             key = "'member:' + #memberId + ':page:' + #pageable.pageNumber + ':status:' + #status + ':sort:' + #sortCreatedAt",
-            unless = "#result.isEmpty()")
-    public Page<SearchAllCouponHistoryResponse> getAllCouponHistoryV2(
+            unless = "#result.content.isEmpty()")
+    public PageResponse<SearchAllCouponHistoryResponse> getAllCouponHistoryV2(
             Long memberId, String status, String sortCreatedAt, Pageable pageable) {
         return couponHistoryRepository.findAllCouponHistoryByMemberId(memberId, status, sortCreatedAt, pageable);
     }


### PR DESCRIPTION
# Work History
- Service에서 Page로 사용하던 부분 PageResponse로 수정
- coupon 도메인 V3 Redis Cache 적용
   - Redis Cache 키, 조회, 저장, 삭제와 관련된 내용은 CouponCacheService에 작성. 
   - CouponService의 V3에서 CouponCacheService를 사용
   - 선착순 쿠폰 발급 신청은 V3-2(Redisson+AOP) 에 Redis Cache 적용
- 쿠폰 정책 조회 시 url 충돌로 정렬/필터 조건이 안 걸리는 이슈 수정
   - /api/v1/coupon-policies -> **/api/v1/couponPolicies**
   - 수정된 url은 임시 수정으로 추가 수정이 필요할 듯함.

# CheckList
- [x] Commit Convention 준수 여부 확인
- [x] 코드에 대해서 주석 작성 여부 확인
- [x] 불필요 주석, import, Test Log 삭제 여부 확인
