### PR TITLE
chore: 쿠폰 락 미적용 테스트 비활성화

### DIFF
--- a/src/test/java/com/example/tradedemo/domain/coupon/CouponConcurrencyTest.java
+++ b/src/test/java/com/example/tradedemo/domain/coupon/CouponConcurrencyTest.java
@@ -10,10 +10,7 @@ import com.example.tradedemo.domain.members.enums.MemberRole;
 import com.example.tradedemo.domain.members.repository.MemberRepository;
 import com.example.tradedemo.domain.wallet.entity.Wallet;
 import com.example.tradedemo.domain.wallet.repository.WalletRepository;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
@@ -98,6 +95,7 @@ public class CouponConcurrencyTest {
      *  -> DeadLock 문제도 함께 발생하고 있음
      */
     @Test
+    @Disabled("Lock을 적용하지 않아 무조건 실패하는 테스트")
     @DisplayName("V2 분산락 적용 전 - 선착순 쿠폰 발급 동시성 테스트")
     void 선착순쿠폰_동시발급() throws InterruptedException {
         // given


### PR DESCRIPTION
# Work History
- 해당 테스트는 락 미적용 동시성 테스트로, 무조건 실패하는 테스트입니다.
- 빌드 시 해당 테스트를 건너뛰게 하기 위해 어노테이션 Disable을 추가했습니다.

# CheckList
- [x] Commit Convention 준수 여부 확인
- [x] 코드에 대해서 주석 작성 여부 확인
- [x] 불필요 주석, import, Test Log 삭제 여부 확인

# ETC