### PR TITLE
feat: 인증/인가/내 정보 redis 도입(V3)

### DIFF
--- a/src/main/java/com/example/tradedemo/auth/config/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/com/example/tradedemo/auth/config/OAuth2AuthenticationSuccessHandler.java
@@ -33,7 +33,7 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
         Member member = principalDetails.getMember();
 
         String accessToken = jwtTokenProvider.createAccessToken(member.getEmail(), member.getRole().name());
-        String refreshToken = jwtTokenProvider.createRefreshToken();
+        String refreshToken = jwtTokenProvider.createRefreshToken(member.getEmail());
 
         // 캐시에 Refresh Token 저장
         Objects.requireNonNull(cacheManager.getCache("refreshTokens")).put(member.getEmail(), refreshToken);

--- a/src/main/java/com/example/tradedemo/auth/config/SecurityConfig.java
+++ b/src/main/java/com/example/tradedemo/auth/config/SecurityConfig.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.cache.CacheManager;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -35,7 +36,8 @@ public class SecurityConfig {
     public SecurityFilterChain filterChain(
             HttpSecurity http, 
             JwtTokenProvider jwtTokenProvider, 
-            CacheManager cacheManager) throws Exception {
+            CacheManager cacheManager,
+            RedisTemplate<String, Object> redisTemplate) throws Exception {
         http.csrf(AbstractHttpConfigurer::disable)
                 .formLogin(AbstractHttpConfigurer::disable)
                 .httpBasic(AbstractHttpConfigurer::disable)
@@ -44,6 +46,7 @@ public class SecurityConfig {
                         auth -> auth.requestMatchers(
                                         "/api/v1/auth/**",
                                         "/api/v2/auth/**",
+                                        "/api/v3/auth/**",
                                         "/api/v2/auth/oauth-success",
                                         "/login/oauth2/**",
                                         "/oauth2/**"
@@ -59,7 +62,7 @@ public class SecurityConfig {
                         .successHandler(oAuth2AuthenticationSuccessHandler)
                 )
                 .addFilterBefore(
-                        new JwtAuthenticationFilter(jwtTokenProvider, cacheManager),
+                        new JwtAuthenticationFilter(jwtTokenProvider, cacheManager, redisTemplate),
                         UsernamePasswordAuthenticationFilter.class)
                 .exceptionHandling(
                         exception -> exception

--- a/src/main/java/com/example/tradedemo/auth/consts/AuthConst.java
+++ b/src/main/java/com/example/tradedemo/auth/consts/AuthConst.java
@@ -1,5 +1,6 @@
 package com.example.tradedemo.auth.consts;
 
+import java.time.Duration;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
@@ -13,6 +14,12 @@ public final class AuthConst {
     public static final long ACCESS_TOKEN_VALIDITY = 1000L * 60 * 30; // 30분
     public static final long REFRESH_TOKEN_VALIDITY = 1000L * 60 * 60 * 24 * 7; // 7일
 
-    // 캐시 이름
+    // 캐시 이름 (Caffeine)
     public static final String BLACKLIST_CACHE_NAME = "blacklistedTokens";
+
+    // V3 Redis 캐시 설정
+    public static final String V3_REFRESH_TOKEN_PREFIX = "v3_refreshTokens:";
+    public static final String V3_BLACKLIST_TOKEN_PREFIX = "v3_blacklistedTokens:";
+    public static final Duration V3_REFRESH_TOKEN_TTL = Duration.ofDays(7).plusHours(1);
+    public static final Duration V3_BLACKLIST_TOKEN_TTL = Duration.ofMinutes(30);
 }

--- a/src/main/java/com/example/tradedemo/auth/controller/AuthController.java
+++ b/src/main/java/com/example/tradedemo/auth/controller/AuthController.java
@@ -8,6 +8,7 @@ import com.example.tradedemo.common.dto.ApiResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -44,7 +45,16 @@ public class AuthController {
     @PostMapping("/v2/auth/login")
     public ResponseEntity<ApiResponse<TokenAuthResponse>> loginV2(@Valid @RequestBody LoginAuthRequest request) {
         TokenAuthResponse tokenResponse = authService.loginV2(request);
-        return ResponseEntity.ok(ApiResponse.success("200", tokenResponse));
+        return ResponseEntity.ok(ApiResponse.success(String.valueOf(HttpStatus.OK), tokenResponse));
+    }
+
+    /**
+     * 로그인 V3
+     */
+    @PostMapping("/v3/auth/login")
+    public ResponseEntity<ApiResponse<TokenAuthResponse>> loginV3(@Valid @RequestBody LoginAuthRequest request) {
+        TokenAuthResponse tokenResponse = authService.loginV3(request);
+        return ResponseEntity.ok(ApiResponse.success(String.valueOf(HttpStatus.OK), tokenResponse));
     }
 
     /**
@@ -63,13 +73,37 @@ public class AuthController {
     }
 
     /**
+     * 로그아웃 V3
+     */
+    @PostMapping("/v3/auth/logout")
+    public ResponseEntity<ApiResponse<Void>> logoutV3(
+            @AuthenticationPrincipal PrincipalDetails principalDetails, HttpServletRequest request) {
+        String authHeader = request.getHeader("Authorization");
+        String accessToken = (authHeader != null && authHeader.startsWith(BEARER_PREFIX))
+                ? authHeader.substring(BEARER_PREFIX.length())
+                : null;
+
+        authService.logoutV3(principalDetails.getEmail(), accessToken);
+        return ResponseEntity.ok(ApiResponse.success("200", null));
+    }
+
+    /**
      * 토큰 재발급 V2
      */
     @PostMapping("/v2/auth/reissue")
-    public ResponseEntity<ApiResponse<TokenAuthResponse>> reissueV2(
-            @AuthenticationPrincipal PrincipalDetails principalDetails, @RequestBody TokenAuthResponse tokenAuthRequest) {
+    public ResponseEntity<ApiResponse<TokenAuthResponse>> reissueV2(@RequestBody TokenAuthResponse tokenAuthRequest) {
         TokenAuthResponse tokenResponse =
-                authService.reissueV2(principalDetails.getEmail(), tokenAuthRequest.refreshToken());
+                authService.reissueV2(tokenAuthRequest.refreshToken());
+        return ResponseEntity.ok(ApiResponse.success("200", tokenResponse));
+    }
+
+    /**
+     * 토큰 재발급 V3
+     */
+    @PostMapping("/v3/auth/reissue")
+    public ResponseEntity<ApiResponse<TokenAuthResponse>> reissueV3(@RequestBody TokenAuthResponse tokenAuthRequest) {
+        TokenAuthResponse tokenResponse =
+                authService.reissueV3(tokenAuthRequest.refreshToken());
         return ResponseEntity.ok(ApiResponse.success("200", tokenResponse));
     }
 

--- a/src/main/java/com/example/tradedemo/auth/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/tradedemo/auth/filter/JwtAuthenticationFilter.java
@@ -17,6 +17,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -28,6 +29,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final JwtTokenProvider jwtTokenProvider;
     private final CacheManager cacheManager;
+    private final RedisTemplate<String, Object> redisTemplate;
     private final ObjectMapper objectMapper = new ObjectMapper();
 
     @Override
@@ -80,8 +82,16 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
      * 블랙리스트 여부 확인
      */
     private boolean isBlacklisted(String token) {
+        return isCaffeineBlacklisted(token) || isRedisBlacklisted(token);
+    }
+
+    private boolean isCaffeineBlacklisted(String token) {
         Cache blacklistCache = cacheManager.getCache(BLACKLIST_CACHE_NAME);
         return blacklistCache != null && blacklistCache.get(token) != null;
+    }
+
+    private boolean isRedisBlacklisted(String token) {
+        return redisTemplate.hasKey(V3_BLACKLIST_TOKEN_PREFIX + token);
     }
 
     /**

--- a/src/main/java/com/example/tradedemo/auth/provider/JwtTokenProvider.java
+++ b/src/main/java/com/example/tradedemo/auth/provider/JwtTokenProvider.java
@@ -42,8 +42,8 @@ public class JwtTokenProvider {
     /**
      * Refresh Token 생성
      */
-    public String createRefreshToken() {
-        return createToken(null, null, REFRESH_TOKEN_VALIDITY);
+    public String createRefreshToken(String email) {
+        return createToken(email, "REFRESH", REFRESH_TOKEN_VALIDITY);
     }
 
     /**

--- a/src/main/java/com/example/tradedemo/auth/service/AuthService.java
+++ b/src/main/java/com/example/tradedemo/auth/service/AuthService.java
@@ -1,5 +1,7 @@
 package com.example.tradedemo.auth.service;
 
+import static com.example.tradedemo.auth.consts.AuthConst.*;
+
 import com.example.tradedemo.auth.dto.*;
 import com.example.tradedemo.auth.provider.JwtTokenProvider;
 import com.example.tradedemo.common.exception.ErrorEnum;
@@ -18,6 +20,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -34,6 +37,7 @@ public class AuthService {
     private final CouponService couponService;
     private final WalletRepository walletRepository;
     private final CacheManager cacheManager;
+    private final RedisTemplate<String, Object> redisTemplate;
 
     /**
      * 회원가입
@@ -85,7 +89,7 @@ public class AuthService {
         String accessToken = jwtTokenProvider.createAccessToken(
                 member.getEmail(), member.getRole().name());
 
-        String refreshToken = jwtTokenProvider.createRefreshToken();
+        String refreshToken = jwtTokenProvider.createRefreshToken(member.getEmail());
 
         member.updateRefreshToken(refreshToken);
         member.updateLastLoginAt();
@@ -130,10 +134,41 @@ public class AuthService {
         // 로그인 처리
         String accessToken = jwtTokenProvider.createAccessToken(
                 member.getEmail(), member.getRole().name());
-        String refreshToken = jwtTokenProvider.createRefreshToken();
+        String refreshToken = jwtTokenProvider.createRefreshToken(member.getEmail());
 
         // 캐시에 저장
         getRefreshCache().put(member.getEmail(), refreshToken);
+
+        member.updateLastLoginAt();
+
+        return new TokenAuthResponse(accessToken, refreshToken);
+    }
+
+    /**
+     * 로그인 V3
+     */
+    @Transactional
+    public TokenAuthResponse loginV3(LoginAuthRequest request) {
+        Member member = memberRepository
+                .findByEmail(request.email())
+                .orElseThrow(() -> new ServiceException(ErrorEnum.ERR_AUTH_MEMBER_NOT_FOUND));
+
+        if (member.getPassword() == null) {
+            throw new ServiceException(ErrorEnum.ERR_AUTH_SOCIAL_ACCOUNT_ONLY);
+        }
+
+        if (!passwordEncoder.matches(request.password(), member.getPassword())) {
+            throw new ServiceException(ErrorEnum.ERR_AUTH_INVALID_PASSWORD);
+        }
+
+        handleMemberStatus(member);
+
+        String accessToken = jwtTokenProvider.createAccessToken(
+                member.getEmail(), member.getRole().name());
+        String refreshToken = jwtTokenProvider.createRefreshToken(member.getEmail());
+
+        // Redis 전용 캐시에 저장
+        redisTemplate.opsForValue().set(V3_REFRESH_TOKEN_PREFIX + member.getEmail(), refreshToken, V3_REFRESH_TOKEN_TTL);
 
         member.updateLastLoginAt();
 
@@ -185,17 +220,35 @@ public class AuthService {
     @CacheEvict(value = "refreshTokens", key = "#email")
     public void logoutV2(String email, String accessToken) {
         // 블랙리스트 전용 캐시 조회
-        Cache blacklistCache = cacheManager.getCache("blacklistedTokens");
+        Cache blacklistCache = cacheManager.getCache(BLACKLIST_CACHE_NAME);
         if (blacklistCache != null) {
             blacklistCache.put(accessToken, "logout");
         }
     }
 
     /**
+     * 로그아웃 V3
+     */
+    @CacheEvict(value = "refreshTokens", key = "#email")
+    public void logoutV3(String email, String accessToken) {
+        // Redis 리프레시 토큰 삭제
+        redisTemplate.delete(V3_REFRESH_TOKEN_PREFIX + email);
+        
+        // 블랙리스트 등록
+        redisTemplate.opsForValue().set(V3_BLACKLIST_TOKEN_PREFIX + accessToken, "logout", V3_BLACKLIST_TOKEN_TTL);
+    }
+
+    /**
      * 토큰 재발급 V2
      */
     @Transactional
-    public TokenAuthResponse reissueV2(String email, String refreshToken) {
+    public TokenAuthResponse reissueV2(String refreshToken) {
+        // 토큰 유효성 검증 및 이메일 추출
+        if (!jwtTokenProvider.validateToken(refreshToken)) {
+            throw new ServiceException(ErrorEnum.ERR_AUTH_EXPIRED_TOKEN);
+        }
+        String email = jwtTokenProvider.getUserEmail(refreshToken);
+
         // 캐시에서 리프레시 토큰 조회
         Cache cache = getRefreshCache();
 
@@ -206,11 +259,6 @@ public class AuthService {
             throw new ServiceException(ErrorEnum.ERR_AUTH_INVALID_TOKEN);
         }
 
-        // 토큰 유효성 검증
-        if (!jwtTokenProvider.validateToken(refreshToken)) {
-            throw new ServiceException(ErrorEnum.ERR_AUTH_EXPIRED_TOKEN);
-        }
-
         Member member = memberRepository
                 .findByEmail(email)
                 .orElseThrow(() -> new ServiceException(ErrorEnum.ERR_AUTH_MEMBER_NOT_FOUND));
@@ -218,10 +266,42 @@ public class AuthService {
         // 새 토큰 생성
         String newAccessToken = jwtTokenProvider.createAccessToken(
                 member.getEmail(), member.getRole().name());
-        String newRefreshToken = jwtTokenProvider.createRefreshToken();
+        String newRefreshToken = jwtTokenProvider.createRefreshToken(member.getEmail());
 
         // 캐시 업데이트
         cache.put(member.getEmail(), newRefreshToken);
+
+        return new TokenAuthResponse(newAccessToken, newRefreshToken);
+    }
+
+    /**
+     * 토큰 재발급 V3
+     */
+    @Transactional
+    public TokenAuthResponse reissueV3(String refreshToken) {
+        // 토큰 유효성 검증 및 이메일 추출
+        if (!jwtTokenProvider.validateToken(refreshToken)) {
+            throw new ServiceException(ErrorEnum.ERR_AUTH_EXPIRED_TOKEN);
+        }
+        String email = jwtTokenProvider.getUserEmail(refreshToken);
+
+        // Redis에서 리프레시 토큰 조회
+        String cachedToken = (String) redisTemplate.opsForValue().get(V3_REFRESH_TOKEN_PREFIX + email);
+
+        if (cachedToken == null || !cachedToken.equals(refreshToken)) {
+            throw new ServiceException(ErrorEnum.ERR_AUTH_INVALID_TOKEN);
+        }
+
+        Member member = memberRepository
+                .findByEmail(email)
+                .orElseThrow(() -> new ServiceException(ErrorEnum.ERR_AUTH_MEMBER_NOT_FOUND));
+
+        String newAccessToken = jwtTokenProvider.createAccessToken(
+                member.getEmail(), member.getRole().name());
+        String newRefreshToken = jwtTokenProvider.createRefreshToken(member.getEmail());
+
+        // Redis 캐시 업데이트
+        redisTemplate.opsForValue().set(V3_REFRESH_TOKEN_PREFIX + member.getEmail(), newRefreshToken, V3_REFRESH_TOKEN_TTL);
 
         return new TokenAuthResponse(newAccessToken, newRefreshToken);
     }

--- a/src/main/java/com/example/tradedemo/common/config/CacheConfig.java
+++ b/src/main/java/com/example/tradedemo/common/config/CacheConfig.java
@@ -12,7 +12,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.JacksonJsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 

--- a/src/main/java/com/example/tradedemo/domain/members/consts/MemberConst.java
+++ b/src/main/java/com/example/tradedemo/domain/members/consts/MemberConst.java
@@ -1,5 +1,7 @@
 package com.example.tradedemo.domain.members.consts;
 
+import java.time.Duration;
+
 public final class MemberConst {
 
     private MemberConst() {}
@@ -9,4 +11,8 @@ public final class MemberConst {
     public static final String REASON_WITHDRAWAL = "사용자 요청에 의한 회원 탈퇴";
     public static final String REASON_DORMANT = "30일 이상 미접속으로 인한 휴면 전환";
     public static final String REASON_ACTIVATE = "계정 활동 재개";
+
+    // V3 Redis 캐시 설정
+    public static final String V3_MEMBER_CACHE_PREFIX = "v3_members:";
+    public static final Duration V3_MEMBER_CACHE_TTL = Duration.ofMinutes(30);
 }

--- a/src/main/java/com/example/tradedemo/domain/members/controller/MemberController.java
+++ b/src/main/java/com/example/tradedemo/domain/members/controller/MemberController.java
@@ -38,6 +38,13 @@ public class MemberController {
         return ResponseEntity.ok(ApiResponse.success("200", response));
     }
 
+    @GetMapping("/v3/me")
+    public ResponseEntity<ApiResponse<GetMyInfoResponse>> getMyInfoV3(
+            @AuthenticationPrincipal PrincipalDetails principalDetails) {
+        GetMyInfoResponse response = memberService.getMyInfoV3(principalDetails.getEmail());
+        return ResponseEntity.ok(ApiResponse.success("200", response));
+    }
+
     /**
      * 내 닉네임 수정
      */
@@ -56,6 +63,15 @@ public class MemberController {
             @RequestBody @Valid UpdateNicknameRequest request) {
 
         memberService.updateNicknameV2(principalDetails.getEmail(), request);
+        return ResponseEntity.ok(ApiResponse.success("200", null));
+    }
+
+    @PatchMapping("/v3/me/nickname")
+    public ResponseEntity<ApiResponse<Void>> updateNicknameV3(
+            @AuthenticationPrincipal PrincipalDetails principalDetails,
+            @RequestBody @Valid UpdateNicknameRequest request) {
+
+        memberService.updateNicknameV3(principalDetails.getEmail(), request);
         return ResponseEntity.ok(ApiResponse.success("200", null));
     }
 
@@ -80,6 +96,15 @@ public class MemberController {
         return ResponseEntity.ok(ApiResponse.success("200", null));
     }
 
+    @PatchMapping("/v3/me/password")
+    public ResponseEntity<ApiResponse<Void>> updatePasswordV3(
+            @AuthenticationPrincipal PrincipalDetails principalDetails,
+            @RequestBody @Valid UpdatePasswordRequest request) {
+
+        memberService.updatePasswordV3(principalDetails.getEmail(), request);
+        return ResponseEntity.ok(ApiResponse.success("200", null));
+    }
+
     /**
      * 회원 탈퇴
      */
@@ -93,6 +118,13 @@ public class MemberController {
     public ResponseEntity<ApiResponse<Void>> deleteMyinfoV2(
             @AuthenticationPrincipal PrincipalDetails principalDetails) {
         memberService.withdrawV2(principalDetails.getEmail());
+        return ResponseEntity.ok(ApiResponse.success("200", null));
+    }
+
+    @DeleteMapping("/v3/me")
+    public ResponseEntity<ApiResponse<Void>> deleteMyinfoV3(
+            @AuthenticationPrincipal PrincipalDetails principalDetails) {
+        memberService.withdrawV3(principalDetails.getEmail());
         return ResponseEntity.ok(ApiResponse.success("200", null));
     }
 
@@ -112,6 +144,14 @@ public class MemberController {
             @AuthenticationPrincipal UserDetails userDetails, @RequestBody @Valid SuspendMemberRequest request) {
 
         memberService.suspendMemberV2(request);
+        return ResponseEntity.ok(ApiResponse.success("200", null));
+    }
+
+    @PatchMapping("/v3/admin/suspend")
+    public ResponseEntity<ApiResponse<Void>> suspendV3(
+            @AuthenticationPrincipal UserDetails userDetails, @RequestBody @Valid SuspendMemberRequest request) {
+
+        memberService.suspendMemberV3(request);
         return ResponseEntity.ok(ApiResponse.success("200", null));
     }
 }

--- a/src/main/java/com/example/tradedemo/domain/members/service/MemberService.java
+++ b/src/main/java/com/example/tradedemo/domain/members/service/MemberService.java
@@ -1,5 +1,8 @@
 package com.example.tradedemo.domain.members.service;
 
+import static com.example.tradedemo.auth.consts.AuthConst.V3_REFRESH_TOKEN_PREFIX;
+import static com.example.tradedemo.domain.members.consts.MemberConst.*;
+
 import com.example.tradedemo.common.exception.ErrorEnum;
 import com.example.tradedemo.common.exception.ServiceException;
 import com.example.tradedemo.domain.marketlistings.enums.MarketListingStatus;
@@ -16,6 +19,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.cache.annotation.Caching;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
@@ -29,6 +33,7 @@ public class MemberService {
     private final PasswordEncoder passwordEncoder;
     private final MarketListingRepository marketListingRepository;
     private final PendingAssetRepository pendingAssetRepository;
+    private final RedisTemplate<String, Object> redisTemplate;
 
     /**
      * 내 정보 조회
@@ -47,6 +52,23 @@ public class MemberService {
                 .findByEmail(email)
                 .orElseThrow(() -> new ServiceException(ErrorEnum.ERR_MEMBER_NOT_FOUND));
         return GetMyInfoResponse.from(member);
+    }
+
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    public GetMyInfoResponse getMyInfoV3(String email) {
+        String cacheKey = V3_MEMBER_CACHE_PREFIX + email;
+        GetMyInfoResponse cached = (GetMyInfoResponse) redisTemplate.opsForValue().get(cacheKey);
+        if (cached != null) {
+            return cached;
+        }
+
+        Member member = memberRepository
+                .findByEmail(email)
+                .orElseThrow(() -> new ServiceException(ErrorEnum.ERR_MEMBER_NOT_FOUND));
+        
+        GetMyInfoResponse response = GetMyInfoResponse.from(member);
+        redisTemplate.opsForValue().set(cacheKey, response, V3_MEMBER_CACHE_TTL);
+        return response;
     }
 
     /**
@@ -85,6 +107,27 @@ public class MemberService {
         member.updateNickname(request.nickname());
     }
 
+    @Transactional
+    @Caching(
+            evict = {
+                @CacheEvict(value = "members", key = "#email"),
+                @CacheEvict(value = "memberAuths", key = "#email")
+            })
+    public void updateNicknameV3(String email, UpdateNicknameRequest request) {
+        Member member = memberRepository
+                .findByEmail(email)
+                .orElseThrow(() -> new ServiceException(ErrorEnum.ERR_MEMBER_NOT_FOUND));
+
+        if (memberRepository.existsByNickname(request.nickname())) {
+            throw new ServiceException(ErrorEnum.ERR_AUTH_DUPLICATE_NICKNAME);
+        }
+
+        member.updateNickname(request.nickname());
+        
+        // V3 캐시 삭제
+        redisTemplate.delete(V3_MEMBER_CACHE_PREFIX + email);
+    }
+
     /**
      * 내 비밀번호 수정
      */
@@ -119,6 +162,27 @@ public class MemberService {
 
         // 새 비밀번호 업데이트
         member.updatePassword(passwordEncoder.encode(request.newPassword()));
+    }
+
+    @Transactional
+    @Caching(
+            evict = {
+                @CacheEvict(value = "members", key = "#email"),
+                @CacheEvict(value = "memberAuths", key = "#email")
+            })
+    public void updatePasswordV3(String email, UpdatePasswordRequest request) {
+        Member member = memberRepository
+                .findByEmail(email)
+                .orElseThrow(() -> new ServiceException(ErrorEnum.ERR_MEMBER_NOT_FOUND));
+
+        if (!passwordEncoder.matches(request.currentPassword(), member.getPassword())) {
+            throw new ServiceException(ErrorEnum.ERR_AUTH_INVALID_PASSWORD);
+        }
+
+        member.updatePassword(passwordEncoder.encode(request.newPassword()));
+        
+        // V3 캐시 삭제
+        redisTemplate.delete(V3_MEMBER_CACHE_PREFIX + email);
     }
 
     /**
@@ -170,6 +234,34 @@ public class MemberService {
         member.clearRefreshToken();
     }
 
+    @Transactional
+    @Caching(
+            evict = {
+                @CacheEvict(value = "members", key = "#email"),
+                @CacheEvict(value = "memberAuths", key = "#email"),
+                @CacheEvict(value = "refreshTokens", key = "#email")
+            })
+    public void withdrawV3(String email) {
+        Member member = memberRepository
+                .findByEmail(email)
+                .orElseThrow(() -> new ServiceException(ErrorEnum.ERR_AUTH_MEMBER_NOT_FOUND));
+
+        if (marketListingRepository.existsByMemberIdAndStatus(member.getId(), MarketListingStatus.SELLING)) {
+            throw new ServiceException(ErrorEnum.ERR_MEMBER_HAS_ACTIVE_LISTINGS);
+        }
+
+        if (pendingAssetRepository.existsByMemberIdAndIsClaimedFalse(member.getId())) {
+            throw new ServiceException(ErrorEnum.ERR_MEMBER_HAS_PENDING_ASSETS);
+        }
+
+        member.withdraw();
+        member.clearRefreshToken();
+        
+        // V3 캐시 삭제
+        redisTemplate.delete(V3_MEMBER_CACHE_PREFIX + email);
+        redisTemplate.delete(V3_REFRESH_TOKEN_PREFIX + email);
+    }
+
     /**
      * 회원 정지(관리자)
      */
@@ -202,6 +294,27 @@ public class MemberService {
         }
 
         member.suspend(request.reason());
+    }
+
+    @Transactional
+    @Caching(
+            evict = {
+                @CacheEvict(value = "members", key = "#request.email()"),
+                @CacheEvict(value = "memberAuths", key = "#request.email()")
+            })
+    public void suspendMemberV3(SuspendMemberRequest request) {
+        Member member = memberRepository
+                .findByEmail(request.email())
+                .orElseThrow(() -> new ServiceException(ErrorEnum.ERR_AUTH_MEMBER_NOT_FOUND));
+
+        if (member.getStatus() == MemberStatus.WITHDRAWN) {
+            throw new ServiceException(ErrorEnum.ERR_AUTH_WITHDRAWN_MEMBER);
+        }
+
+        member.suspend(request.reason());
+        
+        // V3 캐시 삭제
+        redisTemplate.delete(V3_MEMBER_CACHE_PREFIX + request.email());
     }
 
     @Transactional(readOnly = true)


### PR DESCRIPTION
# Work History
1. Redis V3

2. 보안 및 필터 기능 강화
* JwtAuthenticationFilter에서 기존 Caffeine 캐시뿐만 아니라 Redis V3 블랙리스트도 함께 확인하도록 개선했습니다.
* 관리자용 회원 계정 정지 시 Redis에 캐싱된 회원 정보를 즉시 삭제하는 suspendMemberV3 기능을 구현했습니다.

3. 토큰 재발급 로직 안정화
* NullPointerException 해결: Access Token이 만료된 상태에서 재발급(reissue) 호출 시 @AuthenticationPrincipal이 null이 되어 발생하던 문제를 해결했습니다.
개선: 인증 객체에 의존하지 않고, 전달된 Refresh Token에서 직접 사용자 이메일을 추출하여 처리하도록 변경했습니다.
* Refresh Token 구조 변경: Refresh Token 생성 시에도 사용자 이메일을 포함하도록 JwtTokenProvider를 수정하여, 토큰 자체만으로 사용자 식별이 가능하게 했습니다.
* 연관 로직 업데이트: OAuth2AuthenticationSuccessHandler 등 Refresh Token을 생성하는 모든 로직에 이메일 전달 파라미터를 반영했습니다.


# CheckList
- [X] Commit Convention 준수 여부 확인
- [X] 코드에 대해서 주석 작성 여부 확인
- [X] 불필요 주석, import, Test Log 삭제 여부 확인