### PR TITLE
feat: bulk insert 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -89,6 +89,9 @@ dependencies {
 
     // Quartz
     implementation 'org.springframework.boot:spring-boot-starter-quartz'
+
+    // datafaker
+    implementation 'net.datafaker:datafaker:2.0.2'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/tradedemo/common/initializer/dummy/BatchType.java
+++ b/src/main/java/com/example/tradedemo/common/initializer/dummy/BatchType.java
@@ -1,0 +1,8 @@
+package com.example.tradedemo.common.initializer.dummy;
+
+public enum BatchType {
+    MEMBER_ONLY,
+    ITEM_ONLY,
+    MEMBER_ITEM_WITH_BASE,
+    MARKET_LISTING_WITH_BASE
+}

--- a/src/main/java/com/example/tradedemo/common/initializer/dummy/DummyDataRunner.java
+++ b/src/main/java/com/example/tradedemo/common/initializer/dummy/DummyDataRunner.java
@@ -1,0 +1,42 @@
+package com.example.tradedemo.common.initializer.dummy;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Profile("!prod")
+public class DummyDataRunner implements ApplicationRunner {
+
+    private final DummyDataService dummyDataService;
+    private final DummyProperties properties;
+
+    @Override
+    public void run(ApplicationArguments args) throws Exception {
+
+        if(!properties.isEnabled()) return;
+
+        switch (properties.getMode()) {
+            case MEMBER_ONLY -> {
+                dummyDataService.createDummyMember(properties.getMemberCount());
+            }
+            case ITEM_ONLY -> {
+                dummyDataService.createDummyItem(properties.getItemCount());
+            }
+            case MEMBER_ITEM_WITH_BASE -> {
+                dummyDataService.createDummyMember(properties.getMemberCount());
+                dummyDataService.createDummyItem(properties.getItemCount());
+                dummyDataService.createDummyMemberItem(properties.getMemberItemCount());
+            }
+            case MARKET_LISTING_WITH_BASE -> {
+                dummyDataService.createDummyMember(properties.getMemberCount());
+                dummyDataService.createDummyItem(properties.getItemCount());
+                dummyDataService.createDummyMemberItem(properties.getMemberItemCount());
+                dummyDataService.createDummyMarketListing(properties.getMarketListingCount());
+            }
+        }
+    }
+}

--- a/src/main/java/com/example/tradedemo/common/initializer/dummy/DummyDataService.java
+++ b/src/main/java/com/example/tradedemo/common/initializer/dummy/DummyDataService.java
@@ -142,7 +142,7 @@ public class DummyDataService {
 
             // 획득일은 현재 시간 기준 1일 전후로 랜덤값으로 설정
             LocalDateTime acquiredAt = baseTime.plusSeconds(random
-                    .nextLong(-86400, 86401));
+                    .nextLong(-86400, 0));
 
             Long memberId = memberIdList.get(random.nextInt(memberIdList.size()));
             Long itemId = itemIdList.get(random.nextInt(itemIdList.size()));

--- a/src/main/java/com/example/tradedemo/common/initializer/dummy/DummyDataService.java
+++ b/src/main/java/com/example/tradedemo/common/initializer/dummy/DummyDataService.java
@@ -1,0 +1,253 @@
+package com.example.tradedemo.common.initializer.dummy;
+
+import com.example.tradedemo.domain.item.entity.Item;
+import com.example.tradedemo.domain.item.enums.ItemType;
+import com.example.tradedemo.domain.marketlistings.entity.MarketListing;
+import com.example.tradedemo.domain.marketlistings.enums.MarketListingStatus;
+import com.example.tradedemo.domain.marketlistings.enums.SalesDurations;
+import com.example.tradedemo.domain.members.consts.MemberConst;
+import com.example.tradedemo.domain.members.entity.Member;
+import com.example.tradedemo.domain.members.enums.MemberRole;
+import com.example.tradedemo.domain.members.enums.MemberStatus;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import net.datafaker.Faker;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+import java.sql.Timestamp;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.concurrent.ThreadLocalRandom;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class DummyDataService {
+
+    private final JdbcTemplate jdbcTemplate;
+    private final PasswordEncoder passwordEncoder;
+
+    private final Faker faker = new Faker(new Locale("ko"));
+
+    private static final int MEMBER_BATCH_SIZE = 1000;
+    private static final int ITEM_BATCH_SIZE = 1000;
+    private static final int MEMBER_ITEM_BATCH_SIZE = 10000;
+    private static final int MARKET_LISTING_BATCH_SIZE = 10000;
+
+    public void createDummyMember(int totalMemberCount){
+
+        List<Member> batchMembers = new ArrayList<>(MEMBER_BATCH_SIZE);
+
+        String sql = """
+            INSERT INTO members
+            (email, password, nickname, role, status, members.status_changed_at, members.status_reason)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            """;
+
+        String fixedEncodedPassword = passwordEncoder.encode("1234567890");
+
+        for (int i = 0; i < totalMemberCount; i++) {
+            String email = "user" + i + "@test.com";
+            String nickname = faker.funnyName().name() + i;
+            MemberRole role = MemberRole.USER;
+
+            batchMembers.add(Member.create(email, fixedEncodedPassword, nickname, role));
+
+            if(batchMembers.size() == MEMBER_BATCH_SIZE){
+                jdbcTemplate.batchUpdate(sql, batchMembers, MEMBER_BATCH_SIZE, (ps, member) -> {
+                    ps.setString(1, member.getEmail());
+                    ps.setString(2, member.getPassword());
+                    ps.setString(3, member.getNickname());
+                    ps.setString(4, member.getRole().name());
+                    ps.setString(5, member.getStatus().name());
+                    ps.setTimestamp(6, Timestamp.valueOf(member.getStatusChangedAt()));
+                    ps.setString(7, member.getStatusReason());
+                });
+                batchMembers.clear();
+            }
+        }
+
+        if(!batchMembers.isEmpty()){
+            jdbcTemplate.batchUpdate(sql, batchMembers, MEMBER_BATCH_SIZE, (ps, member) -> {
+                ps.setString(1, member.getEmail());
+                ps.setString(2, member.getPassword());
+                ps.setString(3, member.getNickname());
+                ps.setString(4, member.getRole().name());
+                ps.setString(5, member.getStatus().name());
+                ps.setTimestamp(6, Timestamp.valueOf(member.getStatusChangedAt()));
+                ps.setString(7, member.getStatusReason());
+            });
+        }
+    }
+
+    public void createDummyItem(int totalItemCount) {
+        List<Item> batchItems = new ArrayList<>(totalItemCount);
+
+        String sql = """
+            INSERT INTO items
+            (name, item_type)
+            VALUES (?, ?)
+            """;
+
+        for (int i = 0; i < totalItemCount; i++) {
+            String name = faker.minecraft().itemName() + "_" + i;
+            ItemType itemType = ItemType.EQUIPMENT;
+
+            batchItems.add(Item.create(name, itemType));
+
+            if(batchItems.size() == ITEM_BATCH_SIZE){
+                jdbcTemplate.batchUpdate(sql, batchItems, ITEM_BATCH_SIZE, (ps, item) -> {
+                    ps.setString(1, item.getName());
+                    ps.setString(2, item.getItemType().name());
+                });
+                batchItems.clear();
+            }
+        }
+
+        if(!batchItems.isEmpty()){
+            jdbcTemplate.batchUpdate(sql, batchItems, ITEM_BATCH_SIZE, (ps, item) -> {
+                ps.setString(1, item.getName());
+                ps.setString(2, item.getItemType().name());
+            });
+        }
+    }
+
+    public void createDummyMemberItem(int totalMemberItemCount) {
+
+        long start = System.currentTimeMillis();
+
+        List<Long> memberIdList = jdbcTemplate.queryForList("SELECT id FROM members", Long.class);
+        List<Long> itemIdList = jdbcTemplate.queryForList("SELECT id FROM items", Long.class);
+
+        List<Object[]> batchMemberItems = new ArrayList<>(MEMBER_BATCH_SIZE);
+
+        String sql = """
+                INSERT INTO member_items
+                (quantity, acquired_at, member_id, item_id)
+                VALUES (?, ?, ?, ?)
+                """;
+
+        LocalDateTime baseTime = LocalDateTime.now();
+        ThreadLocalRandom random = ThreadLocalRandom.current();
+
+        for(int i = 0 ; i < totalMemberItemCount; i++){
+            Long quantity = random.nextLong(1, 11);
+
+            // 획득일은 현재 시간 기준 1일 전후로 랜덤값으로 설정
+            LocalDateTime acquiredAt = baseTime.plusSeconds(random
+                    .nextLong(-86400, 86401));
+
+            Long memberId = memberIdList.get(random.nextInt(memberIdList.size()));
+            Long itemId = itemIdList.get(random.nextInt(itemIdList.size()));
+
+            batchMemberItems.add(new Object[]{quantity, Timestamp.valueOf(acquiredAt), memberId, itemId});
+
+            if(batchMemberItems.size() == MEMBER_ITEM_BATCH_SIZE){
+                jdbcTemplate.batchUpdate(sql, batchMemberItems);
+                batchMemberItems.clear();
+
+                long elapsed = System.currentTimeMillis() - start;
+
+                log.info("create {} memberItem in {} s", i + 1, elapsed / 1000.0);
+            }
+        }
+
+        if(!batchMemberItems.isEmpty()){
+            jdbcTemplate.batchUpdate(sql, batchMemberItems);
+        }
+    }
+
+    public void createDummyMarketListing(int totalMarketListingCount) {
+
+        long start = System.currentTimeMillis();
+
+        String selectSql = """
+                SELECT mi.id, mi.member_id, mi.quantity, i.name
+                FROM member_items mi
+                join items i on i.id = mi.item_id
+                LIMIT %d
+                """.formatted(totalMarketListingCount);
+
+        // marketListing 더미 데이터 생성을 위한 memberItem 조회
+        List<MemberItemDto> memberItemList = jdbcTemplate.query(selectSql, (rs, rowNum) ->
+                new MemberItemDto(
+                        rs.getLong("id"),
+                        rs.getLong("member_id"),
+                        rs.getLong("quantity"),
+                        rs.getString("name")
+                )
+        );
+
+        if(memberItemList.size() < totalMarketListingCount){
+            throw new RuntimeException("marketListing 생성 수는 memberItem 더미 데이터 수보다 클 수 없습니다");
+        }
+
+        List<Object[]> batchMarketListings = new ArrayList<>(MARKET_LISTING_BATCH_SIZE);
+
+        String insertSql = """
+                INSERT INTO market_listings
+                (item_name, total_price, unit_price, quantity, status, sale_end_at, member_id, member_items_id, created_at, modified_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """;
+
+        LocalDateTime baseTime = LocalDateTime.now();
+        ThreadLocalRandom random = ThreadLocalRandom.current();
+
+        Collections.shuffle(memberItemList);
+
+        for(int i = 0 ; i < totalMarketListingCount; i++){
+            MemberItemDto memberItem = memberItemList.get(i);
+
+            String itemName = memberItem.itemName;
+            BigDecimal unitPrice = BigDecimal.valueOf(random.nextInt(1000, 5001));
+            Long quantity = memberItem.quantity;
+            BigDecimal totalPrice = unitPrice.multiply(BigDecimal.valueOf(quantity));
+            Duration saleDuration = SalesDurations.values()[random.nextInt(SalesDurations.values().length)].getDuration();
+            LocalDateTime createdAt = baseTime.plusSeconds(random.nextLong(0, 86401));
+            LocalDateTime modifiedAt = createdAt;
+            LocalDateTime saleEndAt = createdAt.plus(saleDuration);
+            Long memberId = memberItem.memberId;
+            Long memberItemId = memberItem.memberItemId;
+
+            batchMarketListings.add(new Object[]{
+                    itemName,
+                    totalPrice,
+                    unitPrice,
+                    quantity,
+                    MarketListingStatus.SELLING.name(),
+                    Timestamp.valueOf(saleEndAt),
+                    memberId,
+                    memberItemId,
+                    Timestamp.valueOf(createdAt),
+                    Timestamp.valueOf(modifiedAt)
+            });
+
+            if (batchMarketListings.size() == MARKET_LISTING_BATCH_SIZE) {
+                jdbcTemplate.batchUpdate(insertSql, batchMarketListings);
+                batchMarketListings.clear();
+
+                long elapsed = System.currentTimeMillis() - start;
+
+                log.info("create {} marketListing in {} s", i + 1, elapsed / 1000.0);
+            }
+        }
+
+        if(!batchMarketListings.isEmpty()){
+            jdbcTemplate.batchUpdate(insertSql, batchMarketListings);
+        }
+    }
+
+    private record MemberItemDto(
+            Long memberItemId,
+            Long memberId,
+            Long quantity,
+            String itemName
+    ){}
+}

--- a/src/main/java/com/example/tradedemo/common/initializer/dummy/DummyProperties.java
+++ b/src/main/java/com/example/tradedemo/common/initializer/dummy/DummyProperties.java
@@ -1,0 +1,19 @@
+package com.example.tradedemo.common.initializer.dummy;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@ConfigurationProperties(prefix = "dummy")
+@Component
+public class DummyProperties {
+    private boolean enabled;
+    private BatchType mode;
+    private int memberCount;
+    private int itemCount;
+    private int memberItemCount;
+    private int marketListingCount;
+}


### PR DESCRIPTION
# Work History
작업 내역 적기
- member, item, memberItem, marketListing 더미 데이터 bulk insert 기능 추가
- application-local.yml 에 아래 코드 추가

```yaml
dummy:
  enabled: true
  mode: market_listing_with_base
  member-count: 3000
  item-count: 1000
  member-item-count: 100000
  market-listing-count: 50000 # member-item-count 보다 작거나 같은 경우에만 더미 데이터 생성 가능

```
+ enabeld: false -> 더미 데이터 생성x
+ mode -> BatchType 클래스에 생성 가능한 더미 데이터 타입이 정해져 있음
+ mode: market_listing_with_base 일 경우, member-item-count < market-listing-count 이면 예외 발생

# CheckList
- [ ] Commit Convention 준수 여부 확인
- [ ] 코드에 대해서 주석 작성 여부 확인
- [ ] 불필요 주석, import, Test Log 삭제 여부 확인

# ETC
코드에 대한 설명이나 후처리에 관해 기록할 사항을 적을 것