### PR TITLE
feat: coupon issue v3-3 추가

### DIFF
--- a/src/main/java/com/example/tradedemo/domain/coupon/constants/CouponCacheConst.java
+++ b/src/main/java/com/example/tradedemo/domain/coupon/constants/CouponCacheConst.java
@@ -21,5 +21,8 @@ public final class CouponCacheConst {
     // 쿠폰 사용 내역 캐시 키
     public static final String HISTORIES_PREFIX = "coupon:histories:member:";
 
+    // 쿠폰 사용 내역 캐시 키
+    public static final String RAN_OUT_PREFIX = "coupon:ran_out:";
+
     private CouponCacheConst() {}
 }

--- a/src/main/java/com/example/tradedemo/domain/coupon/controller/CouponController.java
+++ b/src/main/java/com/example/tradedemo/domain/coupon/controller/CouponController.java
@@ -228,6 +228,17 @@ public class CouponController {
                 ApiResponse.success(String.valueOf(HttpStatus.OK.value()), CouponMessage.COUPON_ISSUED));
     }
 
+    @PostMapping("/api/v3-3/coupon-policies/{couponPolicyId}/issue")
+    public ResponseEntity<ApiResponse<String>> issueFirstComeCouponV3_3(
+            @PathVariable Long couponPolicyId, @AuthenticationPrincipal PrincipalDetails principalDetails) {
+
+        Member member = principalDetails.getMember();
+        couponFacade.issueFirstComeCouponV3_3(couponPolicyId, member);
+
+        return ResponseEntity.ok(
+                ApiResponse.success(String.valueOf(HttpStatus.OK.value()), CouponMessage.COUPON_ISSUED));
+    }
+
     /**
      * 내 쿠폰 사용
      */

--- a/src/main/java/com/example/tradedemo/domain/coupon/facade/CouponFacade.java
+++ b/src/main/java/com/example/tradedemo/domain/coupon/facade/CouponFacade.java
@@ -1,5 +1,7 @@
 package com.example.tradedemo.domain.coupon.facade;
 
+import com.example.tradedemo.common.exception.ErrorEnum;
+import com.example.tradedemo.common.exception.ServiceException;
 import com.example.tradedemo.domain.coupon.entity.CouponHistory;
 import com.example.tradedemo.domain.coupon.exception.CouponExpiredException;
 import com.example.tradedemo.domain.coupon.service.CouponCacheService;
@@ -50,6 +52,14 @@ public class CouponFacade {
 
         // 지갑 잔액 추가 + 지갑 히스토리 저장
         walletService.addCouponBalance(wallet, couponHistory, member);
+    }
+
+    public void issueFirstComeCouponV3_3(Long couponPolicyId, Member member) {
+        if (couponCacheService.checkIfCouponRanOut(couponPolicyId)) {
+            throw new ServiceException(ErrorEnum.ERR_COUPON_POLICY_SOLD_OUT);
+        }
+
+        couponService.issueFirstComeCouponV3_2(couponPolicyId, member);
     }
 
     @Transactional(noRollbackFor = CouponExpiredException.class)

--- a/src/main/java/com/example/tradedemo/domain/coupon/service/CouponCacheService.java
+++ b/src/main/java/com/example/tradedemo/domain/coupon/service/CouponCacheService.java
@@ -134,4 +134,22 @@ public class CouponCacheService {
         }
     }
 
+    public String couponRanOutKey(Long couponId) {
+        return CouponCacheConst.RAN_OUT_PREFIX + couponId;
+    }
+
+    public void cacheCouponHasRanOut(Long couponId) {
+        redisTemplate.opsForValue().set(
+                couponRanOutKey(couponId), 
+                Boolean.TRUE, 
+                CouponCacheConst.COUPON_POLICIES_TTL_MINUTES, 
+                TimeUnit.MINUTES
+        );
+    }
+
+    public boolean checkIfCouponRanOut(Long couponId) {
+        Object value = redisTemplate.opsForValue().get(couponRanOutKey(couponId));
+        if (value == null) return false;
+        return true;
+    }
 }

--- a/src/main/java/com/example/tradedemo/domain/coupon/service/CouponService.java
+++ b/src/main/java/com/example/tradedemo/domain/coupon/service/CouponService.java
@@ -399,6 +399,7 @@ public class CouponService {
 
         // 발급 가능 여부 체크
         if (!couponPolicy.isIssuable()) {
+            couponCacheService.cacheCouponHasRanOut(couponPolicyId);
             throw new ServiceException(ErrorEnum.ERR_COUPON_POLICY_SOLD_OUT);
         }
 

--- a/src/test/java/com/example/tradedemo/domain/coupon/CouponConcurrencyTest.java
+++ b/src/test/java/com/example/tradedemo/domain/coupon/CouponConcurrencyTest.java
@@ -5,6 +5,7 @@ import com.example.tradedemo.domain.coupon.enums.IssueType;
 import com.example.tradedemo.domain.coupon.repository.CouponPolicyRepository;
 import com.example.tradedemo.domain.coupon.repository.MemberCouponRepository;
 import com.example.tradedemo.domain.coupon.service.CouponService;
+import com.example.tradedemo.domain.coupon.facade.CouponFacade;
 import com.example.tradedemo.domain.members.entity.Member;
 import com.example.tradedemo.domain.members.enums.MemberRole;
 import com.example.tradedemo.domain.members.repository.MemberRepository;
@@ -24,6 +25,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
 public class CouponConcurrencyTest {
+    @Autowired
+    private CouponFacade couponFacade;
 
     @Autowired
     private CouponService couponService;
@@ -257,6 +260,55 @@ public class CouponConcurrencyTest {
                 try {
                     barrier.await();
                     couponService.issueFirstComeCouponV3_2(couponPolicy.getId(), member);
+                } catch (Exception ignored) {
+                }
+            });
+        }
+
+        executor.shutdown();
+        executor.awaitTermination(100, TimeUnit.SECONDS);
+
+        // then
+        long issuedCount = memberCouponRepository.count();
+        CouponPolicy updatedPolicy = couponPolicyRepository.findById(couponPolicy.getId()).orElseThrow();
+
+        System.out.println("========================================");
+        System.out.println("쿠폰 총 수량:        " + TOTAL_QUANTITY);
+        System.out.println("동시 요청 수:        " + THREAD_COUNT);
+        System.out.println("실제 DB 발급 수:      " + issuedCount);
+        System.out.println("expendQuantity:    " + updatedPolicy.getExpendQuantity());
+        System.out.println("========================================");
+
+        // 선착순 100개, 150명 요청 시 100명 성공
+        // 발급받은 사람 수와 쿠폰 정책이 발급된 수량이 일치해야함
+        assertThat(issuedCount).isEqualTo(updatedPolicy.getExpendQuantity());
+        assertThat(issuedCount).isEqualTo(TOTAL_QUANTITY);
+    }
+
+    /**
+     * V3_3 테스트 결과
+     *  ========================================
+     *  쿠폰 총 수량:        100
+     *  동시 요청 수:        150
+     *  실제 DB 발급 수:      100
+     *  expendQuantity:    100
+     *  ========================================
+     */
+    @Test
+    @DisplayName("V3_3 Redisson 분산락 + AOP 적용 - 선착순 쿠폰 발급 동시성 테스트 + 쿠폰 다 떨어짐 cache")
+    void 선착순쿠폰_동시발급_V3_3() throws InterruptedException {
+
+        // given
+        ExecutorService executor = Executors.newFixedThreadPool(THREAD_COUNT);
+        CyclicBarrier barrier = new CyclicBarrier(THREAD_COUNT);
+
+        // when
+        for (int i = 0; i < THREAD_COUNT; i++) {
+            final Member member = members.get(i);
+            executor.submit(() -> {
+                try {
+                    barrier.await();
+                    couponFacade.issueFirstComeCouponV3_3(couponPolicy.getId(), member);
                 } catch (Exception ignored) {
                 }
             });


### PR DESCRIPTION
# Work History

- coupon 이 다 떨어졌을 경우 redis cache에 기록하기

# CheckList
- [x] Commit Convention 준수 여부 확인
- [x] 코드에 대해서 주석 작성 여부 확인
- [x] 불필요 주석, import, Test Log 삭제 여부 확인

# ETC

현재 redis는 쿠폰이 다 떨어졌을 때도 lock을 세워서 요청을 기다리게
합니다.

이를 해결하기위해 coupon이 다 떨어졌을 경우 그 사실을 redis cache에
기록하고

요청이 추가로 들어오면 redis cache를 다시 확인하게 했습니다.

그리고 그렇게 했을 경우 test 결과

| p90   | p95   | p99   |
| ----- | ----- | ----- |
| 11s   |  11s   |  12s   |

에서

| p90   | p95   | p99   |
| ----- | ----- | ----- |
| 335ms  |  2s   |  2s   |

로 눈에 띄게 성능이 증가하는 것을 확인 하였습니다.

하지만... 스케쥴상 이미 늦었고, refactor에 지장을 줄 수 있기 때문에 draft로 올리겠습니다.