### PR TITLE
refactor: ChatFacade 도입으로 도메인 간 의존 관계 정리

### DIFF
--- a/src/main/java/com/example/tradedemo/domain/chat/controller/ChatController.java
+++ b/src/main/java/com/example/tradedemo/domain/chat/controller/ChatController.java
@@ -5,6 +5,7 @@ import com.example.tradedemo.common.dto.ApiResponse;
 import com.example.tradedemo.domain.chat.dto.ChatMessageResponse;
 import com.example.tradedemo.domain.chat.dto.ChatRoomResponse;
 import com.example.tradedemo.domain.chat.dto.CreateRoomRequest;
+import com.example.tradedemo.domain.chat.facade.ChatFacade;
 import com.example.tradedemo.domain.chat.service.ChatService;
 import com.example.tradedemo.domain.marketlistings.enums.MarketListingStatus;
 import lombok.RequiredArgsConstructor;
@@ -21,6 +22,7 @@ import java.util.List;
 public class ChatController {
 
     private final ChatService chatService;
+    private final ChatFacade chatFacade;
 
     /** 전체 채팅방 목록 */
     @GetMapping("/rooms")
@@ -53,7 +55,7 @@ public class ChatController {
             @AuthenticationPrincipal PrincipalDetails principalDetails) {
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(
                 String.valueOf(HttpStatus.CREATED.value()),
-                chatService.createRoom(request, principalDetails.getEmail())));
+                chatFacade.createRoom(request, principalDetails.getEmail())));
     }
 
     /**

--- a/src/main/java/com/example/tradedemo/domain/chat/facade/ChatFacade.java
+++ b/src/main/java/com/example/tradedemo/domain/chat/facade/ChatFacade.java
@@ -1,0 +1,32 @@
+package com.example.tradedemo.domain.chat.facade;
+
+import com.example.tradedemo.domain.chat.dto.ChatRoomResponse;
+import com.example.tradedemo.domain.chat.dto.CreateRoomRequest;
+import com.example.tradedemo.domain.chat.service.ChatService;
+import com.example.tradedemo.domain.marketlistings.entity.MarketListing;
+import com.example.tradedemo.domain.marketlistings.service.MarketListingService;
+import com.example.tradedemo.domain.members.entity.Member;
+import com.example.tradedemo.domain.members.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ChatFacade {
+
+    private final ChatService chatService;
+    private final MemberService memberService;
+    private final MarketListingService marketListingService;
+
+    public ChatRoomResponse createRoom(CreateRoomRequest request, String buyerEmail) {
+        // 1. 상품 조회 + SELLING 상태 검증
+        MarketListing listing = marketListingService.findMarketListing(request.listingId());
+
+        // 2. 구매자, 판매자 회원 정보 조회
+        Member buyer = memberService.findMemberByEmail(buyerEmail);
+        Member seller = memberService.findMemberByEmail(request.sellerEmail());
+
+        return chatService.createRoom(listing, buyer, seller);
+    }
+
+}

--- a/src/main/java/com/example/tradedemo/domain/chat/service/ChatService.java
+++ b/src/main/java/com/example/tradedemo/domain/chat/service/ChatService.java
@@ -30,9 +30,7 @@ public class ChatService {
 
     private final ChatRoomRepository chatRoomRepository;
     private final ChatRoomMemberRepository chatRoomMemberRepository;
-    private final MemberRepository memberRepository;
     private final ChatMessageRepository chatMessageRepository;
-    private final MarketListingRepository marketListingRepository;
 
     /** 내가 참여한 전체 채팅방 조회 */
     @Transactional(readOnly = true)
@@ -54,47 +52,31 @@ public class ChatService {
 
     /**
      * 채팅방 생성 (상품 탭 "판매자와 채팅하기")
-     * 1. 상품 조회 + SELLING 상태 검증
-     * 2. 같은 구매자 + 같은 상품 중복 채팅방 있으면 예외
-     * 3. 판매자 조회
-     * 4. 채팅방 생성 ("[상품명] 판매자닉네임")
-     * 5. 구매자 = BUYER, 판매자 = SELLER 참여 등록
+     * 1. 같은 구매자 + 같은 상품 중복 채팅방 있으면 예외
+     * 2. 채팅방 생성 ("[상품명] 판매자닉네임")
+     * 3. 구매자 = BUYER, 판매자 = SELLER 참여 등록
      */
-    public ChatRoomResponse createRoom(CreateRoomRequest request, String buyerEmail) {
+    public ChatRoomResponse createRoom(MarketListing marketListing, Member buyer, Member seller) {
 
-        // 1. 상품 조회
-        MarketListing marketListing = marketListingRepository.findById(request.listingId())
-                .orElseThrow(() -> new ServiceException(ErrorEnum.ERR_MARKET_LISTING_NOT_FOUND));
-        // SELLING 상태가 아니면 예외
-        marketListing.validateSelling();
-
-        // 2. 중복 채팅방 존재하는지 확인
+        // 1. 중복 채팅방 존재하는지 확인
         boolean alreadyExists = chatRoomMemberRepository
-                .findRoomByBuyerAndListing(buyerEmail, request.listingId())
+                .findRoomByBuyerAndListing(buyer.getEmail(), marketListing.getId())
                 .isPresent();
 
         if (alreadyExists) {
             throw new ServiceException(ErrorEnum.ERR_CHAT_ROOM_LISTING_ALREADY_EXISTS);
         }
 
-        // 3. 판매자 회원 정보 조회
-        Member seller = memberRepository.findByEmail(request.sellerEmail())
-                .orElseThrow(() -> new ServiceException(ErrorEnum.ERR_MEMBER_NOT_FOUND));
-
-        // 4. 채팅방 생성
+        // 2. 채팅방 생성
         String roomName = "[" + marketListing.getItemName() + "] " + seller.getNickname();
         ChatRoom room = saveRoom(roomName, marketListing);
 
-        // 5. 구매자, 판매자를 채팅방 참여자로 등록
-        Member buyer = memberRepository.findByEmail(buyerEmail).orElseThrow(
-                () -> new ServiceException(ErrorEnum.ERR_MEMBER_NOT_FOUND)
-        );
-
+        // 3. 구매자, 판매자를 채팅방 참여자로 등록
         chatRoomMemberRepository.save(ChatRoomMember.create(room, buyer, ChatRoomMemberRole.BUYER));
         chatRoomMemberRepository.save(ChatRoomMember.create(room, seller, ChatRoomMemberRole.SELLER));
 
         log.info("[ChatRoom] 채팅방 생성 완료 - roomId: {}, buyer: {}, seller: {}",
-                room.getId(), buyerEmail, request.sellerEmail());
+                room.getId(), buyer.getEmail(), seller.getEmail());
 
         return ChatRoomResponse.of(room, seller.getNickname(), ChatRoomMemberRole.BUYER.name(), marketListing.getItemName());
     }

--- a/src/main/java/com/example/tradedemo/domain/members/service/MemberService.java
+++ b/src/main/java/com/example/tradedemo/domain/members/service/MemberService.java
@@ -348,4 +348,10 @@ public class MemberService {
                 .findById(memberId)
                 .orElseThrow(() -> new ServiceException(ErrorEnum.ERR_MEMBER_NOT_FOUND));
     }
+
+    @Transactional(readOnly = true)
+    public Member findMemberByEmail(String email) {
+        return memberRepository.findByEmail(email)
+                .orElseThrow(() -> new ServiceException(ErrorEnum.ERR_MEMBER_NOT_FOUND));
+    }
 }


### PR DESCRIPTION
# Work History
# Facade 도입 이유
ChatService의 createRoom() 내부에서 MemberRepository, MarketListingRepository를 직접 호출해 조회와 검증을 모두 처리하고 있었습니다. 

이는 chat 도메인 Service가 다른 도메인의 Repository에 직접 의존하는 구조로, 
도메인 경계가 무너지고 각 도메인의 비즈니스 로직이 chat 도메인에 누출되는 문제가 있었기 때문에 
이를 해결하기 위해 Facade 레이어를 도입했습니다. 

여러 도메인을 조합하는 책임을 Facade에 명시적으로 분리함으로써, 
각 Service가 자신의 도메인 로직에만 집중할 수 있는 구조로 개선했습니다.

# CheckList
- [x] Commit Convention 준수 여부 확인
- [x] 코드에 대해서 주석 작성 여부 확인
- [x] 불필요 주석, import, Test Log 삭제 여부 확인